### PR TITLE
enforce purs-tidy

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -39,5 +39,7 @@ in {
     cabal-fmt.enable = false;
     optipng.enable = false;
     nixpkgs-fmt.enable = false;
+    purs-tidy.enable = true;
+
   };
 }


### PR DESCRIPTION
WIP
---
Add `purs-tidy` to git pre-commit-hook thus enforce formatting rules to offchain code prior to committing code

## NOTE
PR is marked as WIP, pending mLab's CTL update effort, [PR-75](https://github.com/input-output-hk/partner-chains-smart-contracts/pull/75)
Once PR-75 is merged:
```
cd offchain
make format
```
to format the `offchain` code

## Commits
- add purs-tidy to pre-commit-hook
- reformat all the offchain code.  This step is pending CTL upgrade completion