### PR TITLE
feat: re-add offchain related pkgs from CTL shell

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -54,18 +54,16 @@
   trustless-sidechain-ctl =
     let
       project = repoRoot.nix.offchain;
-      ogmios = inputs.cardano-nix.packages.${system}."ogmios-6.5.0";
-      kupo = inputs.cardano-nix.packages.${system}."kupo-2.9.0";
     in
     project.runPursTest {
       testMain = "Test.Main";
       builtProject = project.compiled;
-      buildInputs = [
+      buildInputs = with inputs.self._packages; [
         ogmios
         kupo
-        inputs.self._packages.cardano-testnet
-        inputs.self._packages.cardano-node
-        inputs.self._packages.cardano-cli
+        cardano-testnet
+        cardano-node
+        cardano-cli
         #pkgs.psmisc # breaks tests on macos
       ];
     };

--- a/nix/offchain.nix
+++ b/nix/offchain.nix
@@ -28,20 +28,7 @@ let
         then ../offchain/package-lock-macos-aarch64.json
         else ../offchain/package-lock.json;
       spagoPackages = ../offchain/spago-packages.nix;
-      withRuntime = true;
-      shell.packages = with pkgs; [
-        # Shell Utils
-        bashInteractive
-        git
-        jq
-
-        # Lint / Format
-        fd
-        dhall
-
-        # CTL Runtime
-        docker
-      ];
+      withRuntime = false;
     };
 in
 offchain

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -39,7 +39,34 @@ in
       hs = inputs.self.devShell;
       ps =
         pkgs.mkShell {
-          packages = [ pkgs.nodejs pkgs.git ];
+          packages = with pkgs; [
+            # Shell Utils
+            bashInteractive
+            git
+            jq
+
+            # Lint / Format
+            fd
+            dhall
+
+            # CTL Runtime
+            docker
+
+            nodejs-18_x
+            nodePackages.node2nix
+
+            # Purescript
+            easy-ps.spago
+            easy-ps.psa
+            easy-ps.spago2nix
+            easy-ps.pscid
+            easy-ps.purs
+            easy-ps.purs-tidy
+
+            inputs.self._packages.ogmios
+            inputs.self._packages.kupo
+
+          ];
           shellHook = ''
             PROJ_ROOT=$(git rev-parse --show-toplevel)
             if [ ! -e "$PROJ_ROOT/offchain/src/TrustlessSidechain/CLIVersion.purs" ]; then
@@ -58,6 +85,8 @@ in
       in
       {
         inherit (cardanoPackages) cardano-node cardano-cli cardano-testnet;
+        ogmios = inputs.cardano-nix.packages.${system}."ogmios-6.5.0";
+        kupo = inputs.cardano-nix.packages.${system}."kupo-2.9.0";
         # This package doesn't work in the check output for some esoteric reason
         sidechain-main-cli-image = inputs.n2c.packages.nix2container.buildImage {
           name = "sidechain-main-cli-docker";


### PR DESCRIPTION
When removing the use of the CTL's runtime overlay, the shell equivalent environment was not migrated locally. This commit brings in those same packages that were present when using the CTL's runtime + shells

### Prereview checklist

- [ ] The [CHANGELOG.md](../blob/master/CHANGELOG.md) has been updated under the `# Unreleased` header using the appropriate sub-headings with links to the appropriate issues/PRs.
- [ ] All tests pass in CI
- [ ] PR was self-reviewed
