### PR TITLE
Move the pc-contracts-cli binary to zip root

### DIFF
--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -14,7 +14,8 @@ rec {
   pc-contracts-release-bundle = pkgs.runCommand "bundled-cli" { buildInputs = [ pkgs.zip ]; } ''
     cp -r ${pc-contracts-cli}/* ./
     mkdir -p $out
-    zip -r $out/release.zip  ./{package.json,node_modules,dist,README.md}
+    zip -r $out/release.zip ./package.json ./node_modules README.md
+    zip -j $out/release.zip ./dist/pc-contracts-cli
   '';
   kupo = pkgs.callPackage ./kupo.nix { };
   ogmios = pkgs.callPackage ./ogmios.nix { };


### PR DESCRIPTION
For the release bundle the binary needs to be at the root

### Prereview checklist

- [ ] The [CHANGELOG.md](../blob/master/CHANGELOG.md) has been updated under the `# Unreleased` header using the appropriate sub-headings with links to the appropriate issues/PRs.
- [ ] All tests pass in CI
- [X] PR was self-reviewed
