### PR TITLE
chore: bump version to v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog](https://keepachangelog.com/en/1.1.0).
 
 # Unreleased
 
+# v6.2.1
+
 ## Fixed
   * CLI now prints errors on stderr instead of stdout
 

--- a/offchain/package.json
+++ b/offchain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@partner-chains/pc-contracts-cli",
   "type": "module",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Partner Chains Smart Contracts CLI",
   "main": "dist/pc-contracts-cli",
   "directories": {

--- a/onchain/trustless-sidechain.cabal
+++ b/onchain/trustless-sidechain.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               trustless-sidechain
-version:            6.2.0
+version:            6.2.1
 synopsis:           TODO
 description:        TODO
 homepage:           https://github.com/mlabs-haskell/trustless-sidechain


### PR DESCRIPTION
### Prereview checklist

- [x] The [CHANGELOG.md](../blob/master/CHANGELOG.md) has been updated under the `# Unreleased` header using the appropriate sub-headings with links to the appropriate issues/PRs.
- [x] All tests pass in CI
- [x] PR was self-reviewed
