### PR TITLE
fix: add missing newline to stderr output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0).
 
 # Unreleased
 
+## Fixed
+  * Add missing newline at end of CLI error output
+
 # v6.2.1
 
 ## Fixed

--- a/offchain/src/Main.purs
+++ b/offchain/src/Main.purs
@@ -142,7 +142,8 @@ main = do
     CLIVersion -> log versionString
 
 failWith :: String -> Effect Unit
-failWith errStr = writeString stderr UTF8 errStr (const $ pure unit) *> exit 1
+failWith errStr = writeString stderr UTF8 (errStr <> "\n") (const $ pure unit)
+  *> exit 1
 
 -- | Reads configuration file from `./config.json`, then
 -- | parses CLI arguments. CLI arguments override the config files.


### PR DESCRIPTION
### Prereview checklist

- [ ] The [CHANGELOG.md](../blob/master/CHANGELOG.md) has been updated under the `# Unreleased` header using the appropriate sub-headings with links to the appropriate issues/PRs.
- [ ] All tests pass in CI
- [ ] PR was self-reviewed
