### PR TITLE
Make pc-contracts-cli the default package

### DIFF
--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -10,6 +10,7 @@ in
 rec {
   inherit (cardanoPackages) cardano-node cardano-cli cardano-testnet;
 
+  default = pc-contracts-cli;
   pc-contracts-cli = offchain.bundled;
   pc-contracts-release-bundle = pkgs.runCommand "bundled-cli" { buildInputs = [ pkgs.zip ]; } ''
     cp -r ${pc-contracts-cli}/* ./


### PR DESCRIPTION
Define pc-contracts-cli as the default package so running `nix build` defaults to building the cli.

### Prereview checklist

- [ ] The [CHANGELOG.md](../blob/master/CHANGELOG.md) has been updated under the `# Unreleased` header using the appropriate sub-headings with links to the appropriate issues/PRs.
- [ ] All tests pass in CI
- [X] PR was self-reviewed
