### PR TITLE
Set LC_ALL in the nix shell

### DIFF
--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -18,6 +18,7 @@ in
     env = {
       CARDANO_CLI = "${cardano-cli}/bin/cardano-cli";
       CARDANO_NODE = "${cardano-node}/bin/cardano-node";
+      LC_ALL = "C.UTF-8";
     };
     nativeBuildInputs = [
       # These packages are all required for running checks present


### PR DESCRIPTION
The integration tests will fail when LC_ALL is not set. So this PR sets LC_ALL in the shell expression to make sure that it's always set

### Prereview checklist

- [ ] Changes have been documented by running `changie new`
- [ ] All tests pass in CI
- [x] PR was self-reviewed
