### PR TITLE
Publish build artifacts on s3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
+      - name: Upload zip to S3
+        run: |
+          nix-shell --run "aws s3 cp offchain/build/release.zip s3://pcsc-bucket/${GITHUB_SHA}.zip --region $AWS_DEFAULT_REGION"
+
       - name: Copy nix scopes to nix cache
         run: |
           nix build .#devShells.x86_64-linux.default --dry-run --json | jq -r '.[] | .drvPath + "^*"' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ on:
       release-version:
         description: "Specify the version number"
         required: true
-      create_draft_release_page:
-        type: boolean
-        description: "Create a draft release page"
 env:
   AWS_DEFAULT_REGION: eu-central-1
 
@@ -20,7 +17,7 @@ jobs:
   partner-chains-smart-contracts-process:
     permissions:
       id-token: write
-      contents: read
+      contents: write
     runs-on: ubuntu-latest
     outputs:
       pc_contracts_cli: ${{ steps.set_filename_vars_and_rename.outputs.pc_contracts_cli }}
@@ -33,63 +30,13 @@ jobs:
 
       - name: Download artifact from S3
         run: |
-          aws s3 cp "s3://pcsc-bucket/${{ github.event.inputs.revision }}.zip" ./artifact.zip
+          aws s3 cp "s3://pcsc-bucket/${{ github.event.inputs.revision }}.zip" ./pc-contracts-cli-v${{ github.event.inputs.release-version }}.zip
 
-      - name: Set filename variables and rename artifact
-        id: set_filename_vars_and_rename
-        run: |
-          PC_CONTRACTS_CLI="pc-contracts-cli-v${{ github.event.inputs.release-version }}.zip"
-          mv ./artifact.zip "./${PC_CONTRACTS_CLI}"
-          echo "pc_contracts_cli=${PC_CONTRACTS_CLI}" >> $GITHUB_OUTPUT
-
-      - name: Upload renamed artifact
-        uses: actions/upload-artifact@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2
         with:
-          name: "${{ steps.set_filename_vars_and_rename.outputs.pc_contracts_cli }}"
-          path: "${{ steps.set_filename_vars_and_rename.outputs.pc_contracts_cli }}"
-
-  release:
-    runs-on: ubuntu-latest
-    needs: partner-chains-smart-contracts-process
-    if: ${{ github.event.inputs.create_draft_release_page == 'true' }}
-    steps:
-      - name: Check if release already exists
-        id: check_release
-        run: |
-          tag="v${{ github.event.inputs.release-version }}"
-          release_response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                            "https://api.github.com/repos/${{ github.repository }}/releases/tags/$tag")
-          if echo "$release_response" | grep -q '"message": "Not Found"'; then
-            echo "release_exists=false" >> $GITHUB_ENV
-            echo "::set-output name=release_exists::false"
-          else
-            echo "release_exists=true" >> $GITHUB_ENV
-            echo "::set-output name=release_exists::true"
-            echo "release_id=$(echo $release_response | jq -r .id)" >> $GITHUB_ENV
-            echo "::set-output name=release_id::$(echo $release_response | jq -r .id)"
-          fi
-
-      - name: Create draft release
-        id: create_release
-        if: ${{ steps.check_release.outputs.release_exists == 'false' }}
-        run: |
-          tag="v${{ github.event.inputs.release-version }}"
-          release_response=$(curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                              -d '{"tag_name": "'$tag'", "name": "'$tag'", "body": "Draft release for '$tag'", "draft": true}' \
-                              "https://api.github.com/repos/${{ github.repository }}/releases")
-          echo "release_id=$(echo $release_response | jq -r .id)" >> $GITHUB_ENV
-          echo "::set-output name=release_id::$(echo $release_response | jq -r .id)"
-
-      - name: Upload renamed artifact to release
-        if: ${{ steps.check_release.outputs.release_exists == 'true' || steps.create_release.outputs.release_id != '' }}
-        run: |
-          release_id="${{ steps.create_release.outputs.release_id }}"
-          if [ -z "$release_id" ]; then
-            release_id="${{ steps.check_release.outputs.release_id }}"
-          fi
-          artifact="${{ needs.partner-chains-smart-contracts-process.outputs.pc_contracts_cli }}"
-          curl -s -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/octet-stream" \
-            --data-binary @"$artifact" \
-            "https://uploads.github.com/repos/${{ github.repository }}/releases/$release_id/assets?name=$(basename $artifact)"
+          body: ""
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ./pc-contracts-cli-v${{ github.event.inputs.release-version }}.zip
+          name: "v${{ github.event.inputs.release-version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ on:
         description: "Git Revision to release"
         required: true
       release-version:
-        description: "Specify the version number"
-        required: true
+        description: "Specify the version number (overwriting the package.json version)"
+        required: false
 env:
   AWS_DEFAULT_REGION: eu-central-1
 
@@ -33,14 +33,23 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
+      - name: Set the version
+        run: |
+          if [ -z "${{ github.event.inputs.release-version }}" ]; then
+            VER=$(jq -r ".version" ./offchain/package.json)
+            echo "VERSION=$VER" >> $GITHUB_ENV
+          else
+            echo "VERSION=${{ github.event.inputs.release-version }}" >> $GITHUB_ENV
+          fi
+
       - name: Download artifact from S3
         run: |
-          aws s3 cp "s3://pcsc-bucket/${{ github.event.inputs.revision }}.zip" ./pc-contracts-cli-v${{ github.event.inputs.release-version }}.zip
+          aws s3 cp "s3://pcsc-bucket/${{ github.event.inputs.revision }}.zip" ./pc-contracts-cli-v"${{ env.VERSION }}".zip
 
       - name: create changes text
         run: |
-          if test -f ./.changes/{{ github.event.inputs.release-version }}.md ; then
-            cp ./.changes/{{ github.event.inputs.release-version }}.md ./release-notes
+          if test -f ./.changes/"$VERSION".md ; then
+            cp ./.changes/.md ./release-notes
           else
             echo "No changie entry for the version specified" > ./release-notes
           fi
@@ -51,5 +60,5 @@ jobs:
           body_path: ./release-notes
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: ./pc-contracts-cli-v${{ github.event.inputs.release-version }}.zip
+          files: ./pc-contracts-cli-v${{ env.VERSION }}.zip
           name: "v${{ github.event.inputs.release-version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ github.token }}
+          ref: ${{ github.event.inputs.revision }}
 
       - name: Acquire AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -61,4 +62,4 @@ jobs:
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
           files: ./pc-contracts-cli-v${{ env.VERSION }}.zip
-          name: "v${{ github.event.inputs.release-version }}"
+          name: "v${{ env.VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,90 +3,60 @@ name: Build, Release, and Publish
 on:
   workflow_dispatch:
     inputs:
-      partner_chains_smart_contracts_sha:
-        description: "Commit SHA or branch to build from"
-      partner-chains-smart-contracts-tag:
-        description: "Specify a new tag or leave empty for default (default: package.json version)"
-        required: false
+      revision:
+        description: "Git Revision to release"
+        required: true
+      release-version:
+        description: "Specify the version number"
+        required: true
       create_draft_release_page:
         type: boolean
         description: "Create a draft release page"
+env:
+  AWS_DEFAULT_REGION: eu-central-1
 
 jobs:
-  partner-chains-smart-contracts:
-    runs-on: [self-hosted, nixos]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.partner_chains_smart_contracts_sha }}
-      - name: Build
-        run: |
-          cd offchain
-          nix-shell --run "make release-zip"
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: partner-chains-smart-contracts
-          path: offchain/build/release.zip
 
   partner-chains-smart-contracts-process:
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
-    needs: partner-chains-smart-contracts
     outputs:
-      pc_contracts_cli: ${{ steps.set_filename_vars.outputs.pc_contracts_cli }}
-      version: ${{ steps.set_version.outputs.version }}
+      pc_contracts_cli: ${{ steps.set_filename_vars_and_rename.outputs.pc_contracts_cli }}
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - name: Acquire AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          name: partner-chains-smart-contracts
-          path: ./non-arch
-      - uses: geekyeggo/delete-artifact@v5
-        with:
-          name: partner-chains-smart-contracts
-      - name: Unzip release.zip
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Download artifact from S3
         run: |
-          mkdir -p ./non-arch/unzipped
-          unzip ./non-arch/release.zip -d ./non-arch/unzipped
-      - name: Set version
-        id: set_version
+          aws s3 cp "s3://pcsc-bucket/${{ github.event.inputs.revision }}.zip" ./artifact.zip
+
+      - name: Set filename variables and rename artifact
+        id: set_filename_vars_and_rename
         run: |
-          if [ -n "${{ github.event.inputs.partner-chains-smart-contracts-tag }}" ]; then
-            echo "version=${{ github.event.inputs.partner-chains-smart-contracts-tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=$(jq -r '.version' ./non-arch/unzipped/package.json)" >> $GITHUB_OUTPUT
-          fi
-      - name: Set filename variables
-        id: set_filename_vars
-        run: |
-          PC_CONTRACTS_CLI="pc-contracts-cli-v${{ steps.set_version.outputs.version }}"
+          PC_CONTRACTS_CLI="pc-contracts-cli-v${{ github.event.inputs.release-version }}.zip"
+          mv ./artifact.zip "./${PC_CONTRACTS_CLI}"
           echo "pc_contracts_cli=${PC_CONTRACTS_CLI}" >> $GITHUB_OUTPUT
-      - name: Zip the artifact
-        run: |
-          cd ./non-arch/unzipped
-          zip -r "../../${{ steps.set_filename_vars.outputs.pc_contracts_cli }}.zip" ./*
-          cd ../../
-      - name: Upload zipped Artifact
+
+      - name: Upload renamed artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "${{ steps.set_filename_vars.outputs.pc_contracts_cli }}.zip"
-          path: "${{ steps.set_filename_vars.outputs.pc_contracts_cli }}.zip"
+          name: "${{ steps.set_filename_vars_and_rename.outputs.pc_contracts_cli }}"
+          path: "${{ steps.set_filename_vars_and_rename.outputs.pc_contracts_cli }}"
 
   release:
     runs-on: ubuntu-latest
     needs: partner-chains-smart-contracts-process
     if: ${{ github.event.inputs.create_draft_release_page == 'true' }}
     steps:
-      - name: Download zipped artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: "${{ needs.partner-chains-smart-contracts-process.outputs.pc_contracts_cli }}.zip"
-          path: ./
       - name: Check if release already exists
         id: check_release
         run: |
-          tag="v${{ needs.partner-chains-smart-contracts-process.outputs.version }}"
+          tag="v${{ github.event.inputs.release-version }}"
           release_response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                             "https://api.github.com/repos/${{ github.repository }}/releases/tags/$tag")
           if echo "$release_response" | grep -q '"message": "Not Found"'; then
@@ -98,24 +68,26 @@ jobs:
             echo "release_id=$(echo $release_response | jq -r .id)" >> $GITHUB_ENV
             echo "::set-output name=release_id::$(echo $release_response | jq -r .id)"
           fi
+
       - name: Create draft release
         id: create_release
         if: ${{ steps.check_release.outputs.release_exists == 'false' }}
         run: |
-          tag="v${{ needs.partner-chains-smart-contracts-process.outputs.version }}"
+          tag="v${{ github.event.inputs.release-version }}"
           release_response=$(curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                               -d '{"tag_name": "'$tag'", "name": "'$tag'", "body": "Draft release for '$tag'", "draft": true}' \
                               "https://api.github.com/repos/${{ github.repository }}/releases")
           echo "release_id=$(echo $release_response | jq -r .id)" >> $GITHUB_ENV
           echo "::set-output name=release_id::$(echo $release_response | jq -r .id)"
-      - name: Upload zipped artifact to release
+
+      - name: Upload renamed artifact to release
         if: ${{ steps.check_release.outputs.release_exists == 'true' || steps.create_release.outputs.release_id != '' }}
         run: |
           release_id="${{ steps.create_release.outputs.release_id }}"
           if [ -z "$release_id" ]; then
             release_id="${{ steps.check_release.outputs.release_id }}"
           fi
-          artifact="${{ needs.partner-chains-smart-contracts-process.outputs.pc_contracts_cli }}.zip"
+          artifact="${{ needs.partner-chains-smart-contracts-process.outputs.pc_contracts_cli }}"
           curl -s -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/octet-stream" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,18 @@ jobs:
         run: |
           aws s3 cp "s3://pcsc-bucket/${{ github.event.inputs.revision }}.zip" ./pc-contracts-cli-v${{ github.event.inputs.release-version }}.zip
 
+      - name: create changes text
+        run: |
+          if test -f ./.changes/{{ github.event.inputs.release-version }}.md ; then
+            cp ./.changes/{{ github.event.inputs.release-version }}.md ./release-notes
+          else
+            echo "No changie entry for the version specified" > ./release-notes
+          fi
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          body_path: ./.changes/${{ github.event.inputs.release-version }}.md
+          body_path: ./release-notes
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
           files: ./pc-contracts-cli-v${{ github.event.inputs.release-version }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
 
-  partner-chains-smart-contracts-process:
+  create-release:
     permissions:
       id-token: write
       contents: write
@@ -22,6 +22,11 @@ jobs:
     outputs:
       pc_contracts_cli: ${{ steps.set_filename_vars_and_rename.outputs.pc_contracts_cli }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ github.token }}
+
       - name: Acquire AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -35,7 +40,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          body: ""
+          body_path: ./.changes/${{ github.event.inputs.release-version }}.md
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
           files: ./pc-contracts-cli-v${{ github.event.inputs.release-version }}.zip

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
           #
           # build tools
           #
+          awscli2
           bashInteractive
           blst
           cabal-install


### PR DESCRIPTION
### Description

This PR introduces the use of a S3 bucket to publish release artifacts:
* The ci.yml copies the release to the bucket
* The release.yml obtains the release referenced by git revision to release

This way there is no need to build anything again during the publish step and the artifact can be regarded as a blessed/tested artifact that can be used for publishing.

Additional changes to the release action:
- Switch to a pre-made GitHub action which makes everything much easier
- Automatically provide changes for the release via changie files
- Fallback to providing some boilerplate text if there is no changie entry
 
### Prereview checklist

- [ ] Changes have been documented by running `changie new`
- [x] All tests pass in CI
- [x] PR was self-reviewed
