### PR TITLE
docs: Remove `since` annotations

### DIFF
--- a/onchain/prelude/TrustlessSidechain/HaskellPrelude.hs
+++ b/onchain/prelude/TrustlessSidechain/HaskellPrelude.hs
@@ -345,8 +345,6 @@ import Witherable qualified
 
 -- | Map the first argument over the list, returning the result as a pair of
 -- lists. Mainly useful for complex state, or the 'State' monad.
---
--- @since v3.0.0
 {-# INLINEABLE mapAndUnzipA #-}
 mapAndUnzipA ::
   forall (a :: Type) (b :: Type) (c :: Type) (f :: Type -> Type).
@@ -357,8 +355,6 @@ mapAndUnzipA ::
 mapAndUnzipA = Monad.mapAndUnzipM
 
 -- | Generalizes 'zipWith' to arbitrary 'Applicative's.
---
--- @since v3.0.0
 {-# INLINEABLE zipWithA #-}
 zipWithA ::
   forall (a :: Type) (b :: Type) (c :: Type) (f :: Type -> Type).
@@ -371,8 +367,6 @@ zipWithA = Monad.zipWithM
 
 -- | As 'zipWithA', but ignores the result: only the effects of @f@ are
 -- performed.
---
--- @since v3.0.0
 {-# INLINEABLE zipWithA_ #-}
 zipWithA_ ::
   forall (a :: Type) (b :: Type) (c :: Type) (f :: Type -> Type).
@@ -385,8 +379,6 @@ zipWithA_ = Monad.zipWithM_
 
 -- | @'replicateA' n act@ performs the action @act@ @'max' 0 n@ times, gathering
 -- the results.
---
--- @since v3.0.0
 {-# INLINEABLE replicateA #-}
 replicateA ::
   forall (a :: Type) (f :: Type -> Type).
@@ -398,8 +390,6 @@ replicateA = Monad.replicateM
 
 -- | As 'replicateA', but ignores the result: only the effects of @f@ are
 -- performed.
---
--- @since v3.0.0
 {-# INLINEABLE replicateA_ #-}
 replicateA_ ::
   forall (a :: Type) (f :: Type -> Type).
@@ -410,8 +400,6 @@ replicateA_ ::
 replicateA_ = Monad.replicateM_
 
 -- | Similar to 'comparing', but for 'Eq' instead of 'Ord'.
---
--- @since v3.0.0
 {-# INLINEABLE equating #-}
 equating ::
   forall (a :: Type) (b :: Type).
@@ -423,8 +411,6 @@ equating ::
 equating f x y = f x == f y
 
 -- | Needed to ensure @if@ works properly.
---
--- @since v3.0.0
 ifThenElse ::
   forall (a :: Type).
   Bool ->
@@ -435,14 +421,10 @@ ifThenElse False _ x = x
 ifThenElse True x _ = x
 
 -- | Check for evenness.
---
--- @since v3.0.0
 even :: forall (a :: Type). (Euclidean a, Ring a, Eq a) => a -> Bool
 even x = (x `rem` 2) == 0
 
 -- | Check for oddness.
---
--- @since v3.0.0
 odd :: forall (a :: Type). (Euclidean a, Ring a, Eq a) => a -> Bool
 odd x = (x `rem` 2) /= 0
 
@@ -457,8 +439,6 @@ odd x = (x `rem` 2) /= 0
 -- \'look like integers\', as it presumes there are only three signa. Thus, for
 -- something like a Gaussian integer (which have five signa) this will not work.
 -- However, we are unlikely to ever need such a type, so this works well enough.
---
--- @since v3.0.0
 signum :: forall (a :: Type). (Ord a, Ring a) => a -> a
 signum x = case compare x zero of
   LT -> negate one
@@ -470,8 +450,6 @@ signum x = case compare x zero of
 -- = Note for mathematical pedants
 --
 -- This has the same caveats on use as 'signum'.
---
--- @since v3.0.0
 abs :: forall (a :: Type). (Ord a, Ring a) => a -> a
 abs x =
   let sig = signum x

--- a/onchain/prelude/TrustlessSidechain/PlutusPrelude.hs
+++ b/onchain/prelude/TrustlessSidechain/PlutusPrelude.hs
@@ -120,8 +120,6 @@ ifThenElse False _ y = y
 --   {\-# INLINEABLE unsafeFromBuiltinData #-\}
 --   unsafeFromBuiltinData = productUnsafeFromData2 Foo
 -- @
---
--- @since v4.0.0
 {-# INLINE productToData2 #-}
 productToData2 ::
   forall (a :: Type) (b :: Type).
@@ -135,8 +133,6 @@ productToData2 x y = Unsafe.mkList go
     go = step1 toBuiltinData x (done1 toBuiltinData y)
 
 -- | As 'productToData2', but for 3-products.
---
--- @since v4.0.0
 {-# INLINE productToData3 #-}
 productToData3 ::
   forall (a :: Type) (b :: Type) (c :: Type).
@@ -160,8 +156,6 @@ productToData3 x y z = Unsafe.mkList go
         )
 
 -- | As 'productToData2', but for 4-products.
---
--- @since v4.0.0
 {-# INLINE productToData4 #-}
 productToData4 ::
   forall (a :: Type) (b :: Type) (c :: Type) (d :: Type).
@@ -190,8 +184,6 @@ productToData4 x1 x2 x3 x4 = Unsafe.mkList go
         )
 
 -- | As 'productToData2', but for 5-products.
---
--- @since v4.0.0
 {-# INLINE productToData5 #-}
 productToData5 ::
   forall
@@ -230,8 +222,6 @@ productToData5 x1 x2 x3 x4 x5 = Unsafe.mkList go
         )
 
 -- | As 'productToData2', but for 6-products.
---
--- @since v4.0.0
 {-# INLINE productToData6 #-}
 productToData6 ::
   forall
@@ -290,8 +280,6 @@ productToData6 x1 x2 x3 x4 x5 x6 = Unsafe.mkList go
 --
 -- Use this function if you don't need any verification beyond the components of
 -- the product decoding successfully.
---
--- @since v4.0.0
 {-# ANN productFromData2 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData2 #-}
 productFromData2 ::
@@ -304,8 +292,6 @@ productFromData2 f = productFromData2' (\x y -> Just (f x y))
 
 -- | As 'productFromData2', but allows additional checks beyond the components
 -- successfully decoding.
---
--- @since v4.0.0
 {-# ANN productFromData2' ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData2' #-}
 productFromData2' ::
@@ -337,8 +323,6 @@ productFromData2' f dat =
         )
 
 -- | As 'productFromData2', but for 3-products.
---
--- @since v4.0.0
 {-# ANN productFromData3 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData3 #-}
 productFromData3 ::
@@ -351,8 +335,6 @@ productFromData3 f = productFromData3' (\x y z -> Just (f x y z))
 
 -- | As 'productFromData3', but allows additional checks beyond the components
 -- successfully decoding.
---
--- @since v4.0.0
 {-# ANN productFromData3' ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData3' #-}
 productFromData3' ::
@@ -388,8 +370,6 @@ productFromData3' f dat =
         )
 
 -- | As 'productFromData2', but for 4-products.
---
--- @since v4.0.0
 {-# ANN productFromData4 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData4 #-}
 productFromData4 ::
@@ -402,8 +382,6 @@ productFromData4 f = productFromData4' (\x1 x2 x3 x4 -> Just (f x1 x2 x3 x4))
 
 -- | As 'productFromData4', but allows additional checks beyond the components
 -- successfully decoding.
---
--- @since v4.0.0
 {-# ANN productFromData4' ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData4' #-}
 productFromData4' ::
@@ -443,8 +421,6 @@ productFromData4' f dat =
         )
 
 -- | As 'productFromData2', but for 5-products.
---
--- @since v4.0.0
 {-# ANN productFromData5 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData5 #-}
 productFromData5 ::
@@ -470,8 +446,6 @@ productFromData5 f =
 
 -- | As 'productFromData5', but allows additional checks beyond the components
 -- successfully decoding.
---
--- @since v4.0.0
 {-# ANN productFromData5' ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData5' #-}
 productFromData5' ::
@@ -526,8 +500,6 @@ productFromData5' f dat =
         )
 
 -- | As 'productFromData2', but for 6-products.
---
--- @since v4.0.0
 {-# ANN productFromData6 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData6 #-}
 productFromData6 ::
@@ -555,8 +527,6 @@ productFromData6 f =
 
 -- | As 'productFromData6', but allows additional checks beyond the components
 -- successfully decoding.
---
--- @since v4.0.0
 {-# ANN productFromData6' ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productFromData6' #-}
 productFromData6' ::
@@ -622,8 +592,6 @@ productFromData6' f dat =
 -- = Note
 --
 -- See 'productToData2' for examples of use, and why this is necessary.
---
--- @since v4.0.0
 {-# ANN productUnsafeFromData2 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productUnsafeFromData2 #-}
 productUnsafeFromData2 ::
@@ -641,8 +609,6 @@ productUnsafeFromData2 f dat =
     (Unsafe.unsafeDataAsList dat)
 
 -- | As 'productUnsafeFromData2', but for 3-products.
---
--- @since v4.0.0
 {-# ANN productUnsafeFromData3 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productUnsafeFromData3 #-}
 productUnsafeFromData3 ::
@@ -664,8 +630,6 @@ productUnsafeFromData3 f dat =
     (Unsafe.unsafeDataAsList dat)
 
 -- | As 'productUnsafeFromData2', but for 4-products.
---
--- @since v4.0.0
 {-# ANN productUnsafeFromData4 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productUnsafeFromData4 #-}
 productUnsafeFromData4 ::
@@ -691,8 +655,6 @@ productUnsafeFromData4 f dat =
     (Unsafe.unsafeDataAsList dat)
 
 -- | As 'productUnsafeFromData2', but for 5-products.
---
--- @since v4.0.0
 {-# ANN productUnsafeFromData5 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productUnsafeFromData5 #-}
 productUnsafeFromData5 ::
@@ -733,8 +695,6 @@ productUnsafeFromData5 f dat =
     (Unsafe.unsafeDataAsList dat)
 
 -- | As 'productUnsafeFromData2', but for 6-products.
---
--- @since v4.0.0
 {-# ANN productUnsafeFromData6 ("HLint: ignore Avoid lambda" :: HString.String) #-}
 {-# INLINE productUnsafeFromData6 #-}
 productUnsafeFromData6 ::

--- a/onchain/src/TrustlessSidechain/Governance/MultiSig.hs
+++ b/onchain/src/TrustlessSidechain/Governance/MultiSig.hs
@@ -29,8 +29,6 @@ import TrustlessSidechain.PlutusPrelude
 -- `MultiSigGovParams` is used to parameterize the multi-signature governance
 -- minting policy, changing the order of elements will change the hash of the
 -- policy.
---
--- @since v6.1.0
 data MultiSigGovParams = MultiSigGovParams
   { governanceMembers :: [PubKeyHash]
   -- ^ Members of the governance
@@ -39,18 +37,15 @@ data MultiSigGovParams = MultiSigGovParams
   }
   deriving (TSPrelude.Show, TSPrelude.Eq)
 
--- | @since v6.1.0
 instance ToData MultiSigGovParams where
   {-# INLINEABLE toBuiltinData #-}
   toBuiltinData (MultiSigGovParams {..}) =
     productToData2 governanceMembers requiredSignatures
 
--- | @since v6.1.0
 instance FromData MultiSigGovParams where
   {-# INLINEABLE fromBuiltinData #-}
   fromBuiltinData = productFromData2 MultiSigGovParams
 
--- | @since v6.1.0
 instance UnsafeFromData MultiSigGovParams where
   {-# INLINEABLE unsafeFromBuiltinData #-}
   unsafeFromBuiltinData = productUnsafeFromData2 MultiSigGovParams

--- a/onchain/src/TrustlessSidechain/Types.hs
+++ b/onchain/src/TrustlessSidechain/Types.hs
@@ -46,25 +46,19 @@ import TrustlessSidechain.PlutusPrelude
 
 -- | 'PermissionedCandidatesPolicyRedeemer' signals whether transaction is supposed to mint or
 -- burn PermissionedCandidates tokens
---
--- @since v5.0.0
 data PermissionedCandidatesPolicyRedeemer
-  = -- | @since v5.0.0
-    PermissionedCandidatesMint
-  | -- | @since v5.0.0
-    PermissionedCandidatesBurn
+  = PermissionedCandidatesMint
+  | PermissionedCandidatesBurn
   deriving stock
     ( TSPrelude.Eq
     , TSPrelude.Show
     )
 
--- | @since v5.0.0
 instance ToData PermissionedCandidatesPolicyRedeemer where
   {-# INLINEABLE toBuiltinData #-}
   toBuiltinData PermissionedCandidatesMint = BuiltinData $ PlutusTx.I 0
   toBuiltinData PermissionedCandidatesBurn = BuiltinData $ PlutusTx.I 1
 
--- | @since v5.0.0
 instance FromData PermissionedCandidatesPolicyRedeemer where
   {-# INLINEABLE fromBuiltinData #-}
   fromBuiltinData x = do
@@ -74,7 +68,6 @@ instance FromData PermissionedCandidatesPolicyRedeemer where
       1 -> Just PermissionedCandidatesBurn
       _ -> Nothing
 
--- | @since v5.0.0
 instance UnsafeFromData PermissionedCandidatesPolicyRedeemer where
   {-# INLINEABLE unsafeFromBuiltinData #-}
   unsafeFromBuiltinData x =
@@ -87,25 +80,19 @@ instance UnsafeFromData PermissionedCandidatesPolicyRedeemer where
 -- | 'PermissionedCandidatesValidatorRedeemer' signals whether transaction is
 -- supposed to update the list of permissioned candidates or remove the list
 -- altogether.
---
--- @since v5.0.0
 data PermissionedCandidatesValidatorRedeemer
-  = -- | @since v5.0.0
-    UpdatePermissionedCandidates
-  | -- | @since v5.0.0
-    RemovePermissionedCandidates
+  = UpdatePermissionedCandidates
+  | RemovePermissionedCandidates
   deriving stock
     ( TSPrelude.Eq
     , TSPrelude.Show
     )
 
--- | @since v5.0.0
 instance ToData PermissionedCandidatesValidatorRedeemer where
   {-# INLINEABLE toBuiltinData #-}
   toBuiltinData UpdatePermissionedCandidates = BuiltinData $ PlutusTx.I 0
   toBuiltinData RemovePermissionedCandidates = BuiltinData $ PlutusTx.I 1
 
--- | @since v5.0.0
 instance FromData PermissionedCandidatesValidatorRedeemer where
   {-# INLINEABLE fromBuiltinData #-}
   fromBuiltinData x = do
@@ -115,7 +102,6 @@ instance FromData PermissionedCandidatesValidatorRedeemer where
       1 -> Just RemovePermissionedCandidates
       _ -> Nothing
 
--- | @since v5.0.0
 instance UnsafeFromData PermissionedCandidatesValidatorRedeemer where
   {-# INLINEABLE unsafeFromBuiltinData #-}
   unsafeFromBuiltinData x =
@@ -284,32 +270,25 @@ instance (UnsafeFromData a) => UnsafeFromData (VersionedGenericDatum a) where
 
 -- | Datum attached to 'VersionOraclePolicy' tokens stored on the
 -- 'VersionOracleValidator' script.
---
--- @since v5.0.0
 newtype VersionOracle = VersionOracle
   { scriptId :: Integer
   -- ^ Unique identifier of the validator.
-  -- @since v5.0.0
   }
   deriving stock (TSPrelude.Show, TSPrelude.Eq)
 
--- | @since v5.0.0
 instance ToData VersionOracle where
   {-# INLINEABLE toBuiltinData #-}
   toBuiltinData VersionOracle {scriptId} =
     toBuiltinData scriptId
 
--- | @since v5.0.0
 instance FromData VersionOracle where
   {-# INLINEABLE fromBuiltinData #-}
   fromBuiltinData x = VersionOracle <$> fromBuiltinData x
 
--- | @since v5.0.0
 instance UnsafeFromData VersionOracle where
   {-# INLINEABLE unsafeFromBuiltinData #-}
   unsafeFromBuiltinData x = VersionOracle $ unsafeFromBuiltinData x
 
--- | @since v5.0.0
 instance Eq VersionOracle where
   VersionOracle s == VersionOracle s' = s == s'
 
@@ -318,75 +297,59 @@ instance Eq VersionOracle where
 data VersionOracleDatum = VersionOracleDatum
   { versionOracle :: VersionOracle
   -- ^ VersionOracle which identifies the script.
-  -- @since v6.0.0
   , currencySymbol :: CurrencySymbol
   -- ^ Currency Symbol of the VersioningOraclePolicy tokens.
-  -- @since v6.0.0
   }
   deriving stock (TSPrelude.Show, TSPrelude.Eq)
 
--- | @since v6.0.0
 instance ToData VersionOracleDatum where
   {-# INLINEABLE toBuiltinData #-}
   toBuiltinData VersionOracleDatum {versionOracle, currencySymbol} =
     productToData2 versionOracle currencySymbol
 
--- | @since v6.0.0
 instance FromData VersionOracleDatum where
   {-# INLINEABLE fromBuiltinData #-}
   fromBuiltinData = productFromData2 VersionOracleDatum
 
--- | @since v6.0.0
 instance UnsafeFromData VersionOracleDatum where
   {-# INLINEABLE unsafeFromBuiltinData #-}
   unsafeFromBuiltinData = productUnsafeFromData2 VersionOracleDatum
 
--- | @since v6.0.0
 instance Eq VersionOracleDatum where
   VersionOracleDatum vO c == VersionOracleDatum vO' c' = vO == vO' && c == c'
 
 -- | Configuration of the versioning system.  Contains currency symbol of
 -- VersionOraclePolicy tokens.  Required to identify versioning tokens that can
 -- be trusted.
---
--- @since v5.0.0
 newtype VersionOracleConfig = VersionOracleConfig
   { versionOracleCurrencySymbol :: CurrencySymbol
   -- ^ @since v5.0.0
   }
   deriving stock (TSPrelude.Show, TSPrelude.Eq)
 
--- | @since v5.0.0
 instance ToData VersionOracleConfig where
   {-# INLINEABLE toBuiltinData #-}
   toBuiltinData VersionOracleConfig {versionOracleCurrencySymbol} =
     toBuiltinData versionOracleCurrencySymbol
 
--- | @since v5.0.0
 instance FromData VersionOracleConfig where
   {-# INLINEABLE fromBuiltinData #-}
   fromBuiltinData x = VersionOracleConfig <$> fromBuiltinData x
 
--- | @since v5.0.0
 instance UnsafeFromData VersionOracleConfig where
   {-# INLINEABLE unsafeFromBuiltinData #-}
   unsafeFromBuiltinData = VersionOracleConfig . unsafeFromBuiltinData
 
 -- | Redeemer for the versioning oracle minting policy that instructs the script
 -- whether to mint or burn versioning tokens.
---
--- @since v5.0.0
 data VersionOraclePolicyRedeemer
   = -- | Mint versioning tokens from init tokens.  Used during sidechain
     -- initialization.
-    -- @since v6.0.0
     InitializeVersionOracle VersionOracle ScriptHash
   | -- | Mint a new versioning token ensuring it contains correct datum and
     -- reference script.
-    -- @since v5.0.0
     MintVersionOracle VersionOracle ScriptHash
   | -- | Burn existing versioning token.
-    -- @since v5.0.0
     BurnVersionOracle VersionOracle
 
 PlutusTx.makeIsDataIndexed

--- a/onchain/test/Main.hs
+++ b/onchain/test/Main.hs
@@ -4,13 +4,10 @@ import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.TrustlessSidechain.Golden.Tests qualified as Golden
 import TrustlessSidechain.HaskellPrelude
 
--- | @since 0.1
 main :: IO ()
 main = defaultMain tests
 
 -- | Project wide tests
---
--- @since 0.1
 tests :: TestTree
 tests =
   testGroup

--- a/onchain/test/roundtrip/Laws.hs
+++ b/onchain/test/roundtrip/Laws.hs
@@ -20,8 +20,6 @@ import TrustlessSidechain.HaskellPrelude
 import TrustlessSidechain.PlutusPrelude qualified as PTPrelude
 
 -- | Verifies that @'fromData' '.' 'toData'@ @=@ @'Just'@.
---
--- @since v4.0.0
 toDataSafeLaws ::
   forall (a :: Type).
   ( Arbitrary a
@@ -34,8 +32,6 @@ toDataSafeLaws ::
 toDataSafeLaws = toDataSafeLaws' @a arbitrary shrink show
 
 -- | Verified that @'unsafeFromData' '.' 'toData'@ @=@ @'id'@.
---
--- @since v4.0.0
 toDataUnsafeLaws ::
   forall (a :: Type).
   ( Arbitrary a
@@ -49,8 +45,6 @@ toDataUnsafeLaws = toDataUnsafeLaws' @a arbitrary shrink show
 
 -- | As 'toDataSafeLaws', but allows a custom generator, shrinker and
 -- prettyprinter.
---
--- @since v4.0.0
 toDataSafeLaws' ::
   forall (a :: Type).
   (PTPrelude.ToData a, PTPrelude.FromData a, Eq a) =>
@@ -75,8 +69,6 @@ toDataSafeLaws' gen shr pprint = forAllShrinkShow gen shr pprint $ \x ->
 
 -- | As 'toDataUnsafeLaws', but allows a custom generator, shrinker and
 -- prettyprinter.
---
--- @since v4.0.0
 toDataUnsafeLaws' ::
   forall (a :: Type).
   (PTPrelude.ToData a, PTPrelude.UnsafeFromData a, Eq a) =>

--- a/onchain/test/roundtrip/Main.hs
+++ b/onchain/test/roundtrip/Main.hs
@@ -161,28 +161,19 @@ shrinkVOC (VersionOracleConfig versionOracleCurrencySymbol) = do
   pure $ VersionOracleConfig sym
 
 -- | Wrapper for 'PubKeyHash' to provide QuickCheck instances.
---
--- @since v4.0.0
 newtype ArbitraryPubKeyHash = ArbitraryPubKeyHash PubKeyHash
   deriving
-    ( -- | @since v4.0.0
-      Eq
-    , -- | @since v4.0.0
-      Ord
-    , -- | @since v4.0.0
-      PTPrelude.Eq
-    , -- | @since v4.0.0
-      PTPrelude.Ord
+    ( Eq
+    , Ord
+    , PTPrelude.Eq
+    , PTPrelude.Ord
     )
     via PubKeyHash
   deriving stock
-    ( -- | @since v4.0.0
-      Show
+    ( Show
     )
 
 -- | Does not shrink, as it doesn't make much sense to.
---
--- @since v4.0.0
 instance Arbitrary ArbitraryPubKeyHash where
   arbitrary =
     ArbitraryPubKeyHash
@@ -192,29 +183,20 @@ instance Arbitrary ArbitraryPubKeyHash where
       <$> vectorOf 28 arbitrary
 
 -- | Wrapper for 'CurrencySymbol' to provide QuickCheck instances.
---
--- @since v4.0.0
 newtype ArbitraryCurrencySymbol = ArbitraryCurrencySymbol CurrencySymbol
   deriving
-    ( -- | @since v4.0.0
-      Eq
-    , -- | @since v4.0.0
-      Ord
-    , -- | @since v4.0.0
-      PTPrelude.Eq
-    , -- | @since v4.0.0
-      PTPrelude.Ord
+    ( Eq
+    , Ord
+    , PTPrelude.Eq
+    , PTPrelude.Ord
     )
     via CurrencySymbol
   deriving stock
-    ( -- | @since v4.0.0
-      Show
+    ( Show
     )
 
 -- | This does /not/ generate the ADA symbol. Does not shrink (it wouldn't make
 -- much sense to).
---
--- @since v4.0.0
 instance Arbitrary ArbitraryCurrencySymbol where
   arbitrary =
     ArbitraryCurrencySymbol

--- a/release.sh
+++ b/release.sh
@@ -5,7 +5,6 @@ semver_pattern="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA
 
 # shellcheck disable=SC2125
 cabalfile=onchain/*.cabal
-hsfiles=$(find onchain/src -type f -name "*.hs")
 
 if [[ -z $IN_NIX_SHELL ]]; then
 	echo "The release script must be run from inside a nix shell"
@@ -40,8 +39,6 @@ changie batch $next_version
 changie merge
 # shellcheck disable=SC2086
 sed -i -r "s/^version:(\s*)\S+$/version:\1$next_version/" $cabalfile
-# shellcheck disable=SC2086
-sed -i -r "s/@since (U|u)nreleased/@since v$next_version/" $hsfiles
 # shellcheck disable=SC2086
 cargo set-version --manifest-path raw-scripts/Cargo.toml $next_version
 # shellcheck disable=SC2086


### PR DESCRIPTION
We are not maintaining these and the existing ones are not useful, only providing noise.