### PR TITLE
Make smart contract spec tests use compiled scripts

### DIFF
--- a/onchain/src/TrustlessSidechain/CommitteeCandidateValidator.hs
+++ b/onchain/src/TrustlessSidechain/CommitteeCandidateValidator.hs
@@ -7,6 +7,7 @@
 module TrustlessSidechain.CommitteeCandidateValidator (
   mkCommitteeCandidateValidator,
   committeeCandidateValidatorUntyped,
+  compiledValidator,
   serialisableValidator,
 ) where
 
@@ -51,6 +52,8 @@ committeeCandidateValidatorUntyped genesisUtxo datum red ctx =
       red
       (unsafeFromBuiltinData ctx)
 
+compiledValidator :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledValidator = $$(PlutusTx.compile [||committeeCandidateValidatorUntyped||])
+
 serialisableValidator :: SerialisedScript
-serialisableValidator =
-  serialiseCompiledCode $$(PlutusTx.compile [||committeeCandidateValidatorUntyped||])
+serialisableValidator = serialiseCompiledCode compiledValidator

--- a/onchain/src/TrustlessSidechain/DParameter.hs
+++ b/onchain/src/TrustlessSidechain/DParameter.hs
@@ -2,6 +2,8 @@
 {-# OPTIONS_GHC -fno-specialise #-}
 
 module TrustlessSidechain.DParameter (
+  compiledMintingPolicy,
+  compiledValidator,
   serialisableMintingPolicy,
   serialisableValidator,
   dParameterValidator,
@@ -125,9 +127,11 @@ mkValidatorUntyped genesisUtxo vc dat redeemer ctx =
       redeemer
       (unsafeFromBuiltinData ctx)
 
+compiledValidator :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledValidator = $$(PlutusTx.compile [||mkValidatorUntyped||])
+
 serialisableValidator :: SerialisedScript
-serialisableValidator =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkValidatorUntyped||])
+serialisableValidator = serialiseCompiledCode compiledValidator
 
 mkMintingPolicyUntyped ::
   BuiltinData ->
@@ -145,6 +149,8 @@ mkMintingPolicyUntyped genesisUtxo vc validatorAddress redeemer ctx =
       redeemer
       (unsafeFromBuiltinData ctx)
 
+compiledMintingPolicy :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledMintingPolicy = $$(PlutusTx.compile [||mkMintingPolicyUntyped||])
+
 serialisableMintingPolicy :: SerialisedScript
-serialisableMintingPolicy =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkMintingPolicyUntyped||])
+serialisableMintingPolicy = serialiseCompiledCode compiledMintingPolicy

--- a/onchain/src/TrustlessSidechain/GovernedMap.hs
+++ b/onchain/src/TrustlessSidechain/GovernedMap.hs
@@ -2,6 +2,8 @@
 {-# OPTIONS_GHC -fno-specialise #-}
 
 module TrustlessSidechain.GovernedMap (
+  compiledMintingPolicy,
+  compiledValidator,
   serialisableMintingPolicy,
   serialisableValidator,
   governedMapValidator,
@@ -92,9 +94,20 @@ mkValidatorUntyped scriptId genesisUtxo vc dat redeemer ctx =
       redeemer
       (unsafeFromBuiltinData ctx)
 
+compiledValidator ::
+  PlutusTx.CompiledCode
+    ( BuiltinData ->
+      BuiltinData ->
+      BuiltinData ->
+      BuiltinData ->
+      BuiltinData ->
+      BuiltinData ->
+      BuiltinUnit
+    )
+compiledValidator = $$(PlutusTx.compile [||mkValidatorUntyped||])
+
 serialisableValidator :: SerialisedScript
-serialisableValidator =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkValidatorUntyped||])
+serialisableValidator = serialiseCompiledCode compiledValidator
 
 mkMintingPolicyUntyped ::
   BuiltinData ->
@@ -112,6 +125,16 @@ mkMintingPolicyUntyped scriptId genesisUtxo vc redeemer ctx =
       redeemer
       (unsafeFromBuiltinData ctx)
 
+compiledMintingPolicy ::
+  PlutusTx.CompiledCode
+    ( BuiltinData ->
+      BuiltinData ->
+      BuiltinData ->
+      BuiltinData ->
+      BuiltinData ->
+      BuiltinUnit
+    )
+compiledMintingPolicy = $$(PlutusTx.compile [||mkMintingPolicyUntyped||])
+
 serialisableMintingPolicy :: SerialisedScript
-serialisableMintingPolicy =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkMintingPolicyUntyped||])
+serialisableMintingPolicy = serialiseCompiledCode compiledMintingPolicy

--- a/onchain/src/TrustlessSidechain/IlliquidCirculationSupply.hs
+++ b/onchain/src/TrustlessSidechain/IlliquidCirculationSupply.hs
@@ -3,6 +3,8 @@
 module TrustlessSidechain.IlliquidCirculationSupply (
   mkIlliquidCirculationSupplyValidatorUntyped,
   mkIlliquidCirculationSupplyAuthorityTokenPolicyUntyped,
+  compiledValidator,
+  compiledAuthorityTokenPolicy,
   serialisableIlliquidCirculationSupplyValidator,
   serialisableIlliquidCirculationSupplyAuthorityTokenPolicy,
 ) where
@@ -148,9 +150,11 @@ mkIlliquidCirculationSupplyValidatorUntyped voc rd rr ctx =
       (PlutusTx.unsafeFromBuiltinData rr)
       (PlutusTx.unsafeFromBuiltinData ctx)
 
+compiledValidator :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledValidator = $$(PlutusTx.compile [||mkIlliquidCirculationSupplyValidatorUntyped||])
+
 serialisableIlliquidCirculationSupplyValidator :: SerialisedScript
-serialisableIlliquidCirculationSupplyValidator =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkIlliquidCirculationSupplyValidatorUntyped||])
+serialisableIlliquidCirculationSupplyValidator = serialiseCompiledCode compiledValidator
 
 mkIlliquidCirculationSupplyAuthorityTokenPolicy :: BuiltinData -> VersionOracleConfig -> BuiltinData -> ScriptContext -> Bool
 mkIlliquidCirculationSupplyAuthorityTokenPolicy _scriptId voc _ ctx =
@@ -169,6 +173,8 @@ mkIlliquidCirculationSupplyAuthorityTokenPolicyUntyped _scriptId voc rd ctx =
       rd
       (PlutusTx.unsafeFromBuiltinData ctx)
 
+compiledAuthorityTokenPolicy :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledAuthorityTokenPolicy = $$(PlutusTx.compile [||mkIlliquidCirculationSupplyAuthorityTokenPolicyUntyped||])
+
 serialisableIlliquidCirculationSupplyAuthorityTokenPolicy :: SerialisedScript
-serialisableIlliquidCirculationSupplyAuthorityTokenPolicy =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkIlliquidCirculationSupplyAuthorityTokenPolicyUntyped||])
+serialisableIlliquidCirculationSupplyAuthorityTokenPolicy = serialiseCompiledCode compiledAuthorityTokenPolicy

--- a/onchain/src/TrustlessSidechain/PermissionedCandidates.hs
+++ b/onchain/src/TrustlessSidechain/PermissionedCandidates.hs
@@ -4,6 +4,8 @@
 -- | This module provides functionality for storing a list of permissioned
 -- candidates on the mainchain so that it can be accessed by the sidechain.
 module TrustlessSidechain.PermissionedCandidates (
+  compiledValidator,
+  compiledMintingPolicy,
   serialisableValidator,
   serialisableMintingPolicy,
   permissionedCandidatesValidator,
@@ -193,9 +195,11 @@ mkMintingPolicyUntyped genesisUtxo vc validatorAddress redeemer ctx =
       (unsafeFromBuiltinData redeemer)
       (unsafeFromBuiltinData ctx)
 
+compiledMintingPolicy :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledMintingPolicy = $$(PlutusTx.compile [||mkMintingPolicyUntyped||])
+
 serialisableMintingPolicy :: SerialisedScript
-serialisableMintingPolicy =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkMintingPolicyUntyped||])
+serialisableMintingPolicy = serialiseCompiledCode compiledMintingPolicy
 
 mkValidatorUntyped ::
   BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit
@@ -208,6 +212,8 @@ mkValidatorUntyped genesisUtxo vc datum redeemer ctx =
       (unsafeFromBuiltinData redeemer)
       (unsafeFromBuiltinData ctx)
 
+compiledValidator :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledValidator = $$(PlutusTx.compile [||mkValidatorUntyped||])
+
 serialisableValidator :: SerialisedScript
-serialisableValidator =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkValidatorUntyped||])
+serialisableValidator = serialiseCompiledCode compiledValidator

--- a/onchain/src/TrustlessSidechain/Reserve.hs
+++ b/onchain/src/TrustlessSidechain/Reserve.hs
@@ -8,9 +8,11 @@
 module TrustlessSidechain.Reserve (
   mkReserveValidator,
   mkReserveValidatorUntyped,
+  compiledValidator,
   serialisableReserveValidator,
   mkReserveAuthPolicy,
   mkReserveAuthPolicyUntyped,
+  compiledReserveAuthPolicy,
   serialisableReserveAuthPolicy,
   reserveAuthTokenTokenName,
 ) where
@@ -273,9 +275,11 @@ mkReserveValidatorUntyped voc rd rr ctx =
       (PlutusTx.unsafeFromBuiltinData rr)
       (PlutusTx.unsafeFromBuiltinData ctx)
 
+compiledValidator :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledValidator = $$(PlutusTx.compile [||mkReserveValidatorUntyped||])
+
 serialisableReserveValidator :: SerialisedScript
-serialisableReserveValidator =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkReserveValidatorUntyped||])
+serialisableReserveValidator = serialiseCompiledCode compiledValidator
 
 {-# INLINEABLE extractReserveUtxoDatum #-}
 extractReserveUtxoDatum :: TxOut -> Maybe (VersionedGenericDatum ReserveDatum)
@@ -368,9 +372,11 @@ mkReserveAuthPolicyUntyped voc red ctx =
       (PlutusTx.unsafeFromBuiltinData red)
       (PlutusTx.unsafeFromBuiltinData ctx)
 
+compiledReserveAuthPolicy :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledReserveAuthPolicy = $$(PlutusTx.compile [||mkReserveAuthPolicyUntyped||])
+
 serialisableReserveAuthPolicy :: SerialisedScript
-serialisableReserveAuthPolicy =
-  serialiseCompiledCode $$(PlutusTx.compile [||mkReserveAuthPolicyUntyped||])
+serialisableReserveAuthPolicy = serialiseCompiledCode compiledReserveAuthPolicy
 
 -- | Takes a decoded piece of data and turns it into the wrapped `BuiltinData` equivalent
 --   provided by `asData`, to make it compatible with functions from `PlutusLedgerApi.Vn.Data` modules.

--- a/onchain/src/TrustlessSidechain/Versioning.hs
+++ b/onchain/src/TrustlessSidechain/Versioning.hs
@@ -10,6 +10,8 @@
 -- versioning tokens.  Each versioning token stores a reference script and a
 -- datum that identifies the script and its version.
 module TrustlessSidechain.Versioning (
+  compiledVersionOraclePolicy,
+  compiledVersionOracleValidator,
   serialisableVersionOraclePolicy,
   serialisableVersionOracleValidator,
   mkVersionOraclePolicy,
@@ -198,11 +200,12 @@ mkVersionOraclePolicyUntyped genesisUtxo validatorAddress redeemer ctx =
       (unsafeFromBuiltinData redeemer)
       (unsafeFromBuiltinData ctx)
 
+compiledVersionOraclePolicy :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledVersionOraclePolicy = $$(PlutusTx.compile [||mkVersionOraclePolicyUntyped||])
+
 serialisableVersionOraclePolicy ::
   SerialisedScript
-serialisableVersionOraclePolicy =
-  serialiseCompiledCode
-    $$(PlutusTx.compile [||mkVersionOraclePolicyUntyped||])
+serialisableVersionOraclePolicy = serialiseCompiledCode compiledVersionOraclePolicy
 
 -- | Stores VersionOraclePolicy UTxOs, acting both as an oracle of available
 -- scripts as well as a script caching system.  UTxOs on the script are managed
@@ -267,11 +270,12 @@ mkVersionOracleValidatorUntyped genesisUtxo datum redeemer ctx =
       (PlutusTx.unsafeFromBuiltinData redeemer)
       (unsafeFromBuiltinData ctx)
 
+compiledVersionOracleValidator :: PlutusTx.CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+compiledVersionOracleValidator = $$(PlutusTx.compile [||mkVersionOracleValidatorUntyped||])
+
 serialisableVersionOracleValidator ::
   SerialisedScript
-serialisableVersionOracleValidator =
-  serialiseCompiledCode
-    $$(PlutusTx.compile [||mkVersionOracleValidatorUntyped||])
+serialisableVersionOracleValidator = serialiseCompiledCode compiledVersionOracleValidator
 
 -- | Searches for a specified validator script passed as a reference input.
 -- Note that if requested script ID corresponds to a minting policy this

--- a/onchain/test/script-spec/CommitteeCandidateValidator.hs
+++ b/onchain/test/script-spec/CommitteeCandidateValidator.hs
@@ -32,7 +32,7 @@ committeeCandidateValidatorPassing =
 
 committeeCandidateValidatorFailing :: TestTree
 committeeCandidateValidatorFailing =
-  expectFail "should fail if not signed by the original submitter (ERROR-COMMITTEE-CANDIDATE-VALIDATOR-01)" $
+  expectFail "should fail if not signed by the original submitter" "ERROR-COMMITTEE-CANDIDATE-VALIDATOR-01" $
     runValidator
       Test.genesisUtxo
       committeeCandidateValidatorDatum
@@ -54,10 +54,10 @@ someTxOutRef = V2.TxOutRef "abcd0123" 0
 committeeCandidateValidatorDatum :: VersionedGenericDatum V2.PubKeyHash
 committeeCandidateValidatorDatum = VersionedGenericDatum pubKeyHash Test.dummyBuiltinData 0
 
-runValidator :: V2.TxOutRef -> VersionedGenericDatum V2.PubKeyHash -> BuiltinData -> V2.ScriptContext -> BuiltinUnit
+runValidator :: V2.TxOutRef -> VersionedGenericDatum V2.PubKeyHash -> BuiltinData -> V2.ScriptContext -> CompiledCode BuiltinUnit
 runValidator genesisUtxo datum redeemer ctx =
-  committeeCandidateValidatorUntyped
-    (toBuiltinData genesisUtxo)
-    (toBuiltinData datum)
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
+  compiledValidator
+    `appArg` genesisUtxo
+    `appArg` datum
+    `appArg` redeemer
+    `appArg` ctx

--- a/onchain/test/script-spec/DParameter.hs
+++ b/onchain/test/script-spec/DParameter.hs
@@ -43,7 +43,7 @@ dParamMintingPolicyPassing =
 
 dParamMintingPolicyFailing01 :: TestTree
 dParamMintingPolicyFailing01 =
-  expectFail "should fail if not signed by the governance authority (ERROR-DPARAMETER-POLICY-01)" $
+  expectFail "should fail if not signed by the governance authority" "ERROR-DPARAMETER-POLICY-01" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -61,7 +61,7 @@ dParamMintingPolicyFailing01 =
 
 dParamMintingPolicyFailing02 :: TestTree
 dParamMintingPolicyFailing02 =
-  expectFail "should fail if some tokens are not sent to dParameterValidatorAddress (ERROR-DPARAMETER-POLICY-02)" $
+  expectFail "should fail if some tokens are not sent to dParameterValidatorAddress" "ERROR-DPARAMETER-POLICY-02" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -89,7 +89,7 @@ dParamMintingPolicyFailing02 =
 
 dParamMintingPolicyFailing03 :: TestTree
 dParamMintingPolicyFailing03 =
-  expectFail "should fail if script purpose is not Minting (ERROR-DPARAMETER-POLICY-03)" $
+  expectFail "should fail if script purpose is not Minting" "ERROR-DPARAMETER-POLICY-03" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -161,7 +161,7 @@ dParamValidatorPassingSpending =
 
 dParamValidatorFailing01 :: TestTree
 dParamValidatorFailing01 =
-  expectFail "should fail if not signed by the governance authority (ERROR-DPARAMETER-VALIDATOR-01)" $
+  expectFail "should fail if not signed by the governance authority" "ERROR-DPARAMETER-VALIDATOR-01" $
     runValidator
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -195,20 +195,20 @@ dParameterOracleToken = V2.singleton dParameterCurrSym dParameterOracleTokenName
 
 -- test runner
 
-runMintingPolicy :: V2.TxOutRef -> VersionOracleConfig -> V2.Address -> BuiltinData -> V2.ScriptContext -> BuiltinUnit
+runMintingPolicy :: V2.TxOutRef -> VersionOracleConfig -> V2.Address -> BuiltinData -> V2.ScriptContext -> CompiledCode BuiltinUnit
 runMintingPolicy genesisUtxo vc dParameterValidatorAddress' redeemer ctx =
-  mkMintingPolicyUntyped
-    (toBuiltinData genesisUtxo)
-    (toBuiltinData vc)
-    (toBuiltinData dParameterValidatorAddress')
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
+  compiledMintingPolicy
+    `appArg` genesisUtxo
+    `appArg` vc
+    `appArg` dParameterValidatorAddress'
+    `appArg` redeemer
+    `appArg` ctx
 
-runValidator :: V2.TxOutRef -> VersionOracleConfig -> BuiltinData -> BuiltinData -> V2.ScriptContext -> BuiltinUnit
+runValidator :: V2.TxOutRef -> VersionOracleConfig -> BuiltinData -> BuiltinData -> V2.ScriptContext -> CompiledCode BuiltinUnit
 runValidator genesisUtxo vc datum redeemer ctx =
-  mkValidatorUntyped
-    (toBuiltinData genesisUtxo)
-    (toBuiltinData vc)
-    (toBuiltinData datum)
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
+  compiledValidator
+    `appArg` genesisUtxo
+    `appArg` vc
+    `appArg` datum
+    `appArg` redeemer
+    `appArg` ctx

--- a/onchain/test/script-spec/GovernedMap.hs
+++ b/onchain/test/script-spec/GovernedMap.hs
@@ -45,7 +45,7 @@ governedMapPolicyPassing =
 
 governedMapPolicyFailing :: TestTree
 governedMapPolicyFailing =
-  expectFail "should fail if not signed by the governance authority (ERROR-GOVERNED-MAP-POLICY-01)" $
+  expectFail "should fail if not signed by the governance authority" "ERROR-GOVERNED-MAP-POLICY-01" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -76,7 +76,7 @@ governedMapValidatorPassing =
 
 governedMapValidatorFailing :: TestTree
 governedMapValidatorFailing =
-  expectFail "should fail if not signed by the governance authority (ERROR-GOVERNED-MAP-VALIDATOR-01)" $
+  expectFail "should fail if not signed by the governance authority" "ERROR-GOVERNED-MAP-VALIDATOR-01" $
     runValidator
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -99,25 +99,6 @@ governedMapTokenUtxo =
 someTxOutRef :: V2.TxOutRef
 someTxOutRef = V2.TxOutRef "abcd0123" 0
 
-runMintingPolicy :: V2.TxOutRef -> Types.VersionOracleConfig -> BuiltinData -> V2.ScriptContext -> BuiltinUnit
-runMintingPolicy genesisUtxo vc redeemer ctx =
-  mkMintingPolicyUntyped
-    (toBuiltinData governedMapPolicyId)
-    (toBuiltinData genesisUtxo)
-    (toBuiltinData vc)
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
-
-runValidator :: V2.TxOutRef -> Types.VersionOracleConfig -> BuiltinData -> BuiltinData -> V2.ScriptContext -> BuiltinUnit
-runValidator genesisUtxo vc datum redeemer ctx =
-  mkValidatorUntyped
-    (toBuiltinData governedMapValidatorId)
-    (toBuiltinData genesisUtxo)
-    (toBuiltinData vc)
-    (toBuiltinData datum)
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
-
 governedMapCurrSym :: V2.CurrencySymbol
 governedMapCurrSym = V2.CurrencySymbol "governedMapCurrSym"
 
@@ -129,3 +110,24 @@ governedMapToken = V2.singleton governedMapCurrSym governedMapTokenName
 
 governedMapValidatorAddress :: V2.Address
 governedMapValidatorAddress = V2.Address (V2.PubKeyCredential "01230123012301230123012301230123012301230123012301230123") Nothing
+
+-- test runner
+
+runMintingPolicy :: V2.TxOutRef -> Types.VersionOracleConfig -> BuiltinData -> V2.ScriptContext -> CompiledCode BuiltinUnit
+runMintingPolicy genesisUtxo vc redeemer ctx =
+  compiledMintingPolicy
+    `appArg` governedMapPolicyId
+    `appArg` genesisUtxo
+    `appArg` vc
+    `appArg` redeemer
+    `appArg` ctx
+
+runValidator :: V2.TxOutRef -> Types.VersionOracleConfig -> BuiltinData -> BuiltinData -> V2.ScriptContext -> CompiledCode BuiltinUnit
+runValidator genesisUtxo vc datum redeemer ctx =
+  compiledValidator
+    `appArg` governedMapValidatorId
+    `appArg` genesisUtxo
+    `appArg` vc
+    `appArg` datum
+    `appArg` redeemer
+    `appArg` ctx

--- a/onchain/test/script-spec/IlliquidCirculationSupply.hs
+++ b/onchain/test/script-spec/IlliquidCirculationSupply.hs
@@ -27,7 +27,7 @@ policyTests =
 illiquidCirculationSupplyAuthorityTokenPolicyPassing :: TestTree
 illiquidCirculationSupplyAuthorityTokenPolicyPassing =
   expectSuccess "should pass" $
-    runPolicy
+    runMintingPolicy
       Test.versionOracleConfig
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting icsAuthorityTokenCurrSym
@@ -40,8 +40,8 @@ illiquidCirculationSupplyAuthorityTokenPolicyPassing =
 
 illiquidCirculationSupplyAuthorityTokenPolicyFailing01 :: TestTree
 illiquidCirculationSupplyAuthorityTokenPolicyFailing01 =
-  expectFail "should fail if not signed by the governance authority (ERROR-ICS-AUTH-TOKEN-01)" $
-    runPolicy
+  expectFail "should fail if not signed by the governance authority" "ERROR-ICS-AUTH-TOKEN-01" $
+    runMintingPolicy
       Test.versionOracleConfig
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting icsAuthorityTokenCurrSym
@@ -106,7 +106,7 @@ illiquidCirculationSupplyValidatorDepositPassing =
 
 illiquidCirculationSupplyValidatorDepositFailing01a :: TestTree
 illiquidCirculationSupplyValidatorDepositFailing01a =
-  expectFail "should fail if output UTxO has 0 ICS Authority Tokens (ERROR-ILLIQUID-CIRCULATION-SUPPLY-01)" $
+  expectFail "should fail if output UTxO has 0 ICS Authority Tokens" "ERROR-ILLIQUID-CIRCULATION-SUPPLY-01" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -135,7 +135,7 @@ illiquidCirculationSupplyValidatorDepositFailing01a =
 
 illiquidCirculationSupplyValidatorDepositFailing01b :: TestTree
 illiquidCirculationSupplyValidatorDepositFailing01b =
-  expectFail "should fail if output UTxO has 2 ICS Authority Tokens (ERROR-ILLIQUID-CIRCULATION-SUPPLY-01)" $
+  expectFail "should fail if output UTxO has 2 ICS Authority Tokens" "ERROR-ILLIQUID-CIRCULATION-SUPPLY-01" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -164,7 +164,7 @@ illiquidCirculationSupplyValidatorDepositFailing01b =
 
 illiquidCirculationSupplyValidatorDepositFailing02 :: TestTree
 illiquidCirculationSupplyValidatorDepositFailing02 =
-  expectFail "should fail if assets of the supply UTxO decreased (ERROR-ILLIQUID-CIRCULATION-SUPPLY-02)" $
+  expectFail "should fail if assets of the supply UTxO decreased" "ERROR-ILLIQUID-CIRCULATION-SUPPLY-02" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -193,7 +193,7 @@ illiquidCirculationSupplyValidatorDepositFailing02 =
 
 illiquidCirculationSupplyValidatorDepositFailing03 :: TestTree
 illiquidCirculationSupplyValidatorDepositFailing03 =
-  expectFail "should fail if ICS auth tokens leak from the ICS validator (ERROR-ILLIQUID-CIRCULATION-SUPPLY-03)" $
+  expectFail "should fail if ICS auth tokens leak from the ICS validator" "ERROR-ILLIQUID-CIRCULATION-SUPPLY-03" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -227,7 +227,7 @@ illiquidCirculationSupplyValidatorDepositFailing03 =
 
 illiquidCirculationSupplyValidatorDepositFailing05 :: TestTree
 illiquidCirculationSupplyValidatorDepositFailing05 =
-  expectFail "should fail if no unique output UTxO at the supply address (ERROR-ILLIQUID-CIRCULATION-SUPPLY-05)" $
+  expectFail "should fail if no unique output UTxO at the supply address" "ERROR-ILLIQUID-CIRCULATION-SUPPLY-05" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -277,7 +277,7 @@ illiquidCirculationSupplyValidatorWithdrawPassing =
 
 illiquidCirculationSupplyValidatorWithdrawFailing04 :: TestTree
 illiquidCirculationSupplyValidatorWithdrawFailing04 =
-  expectFail "should fail if single illiquid circulation supply token is not minted (ERROR-ILLIQUID-CIRCULATION-SUPPLY-04)" $
+  expectFail "should fail if single illiquid circulation supply token is not minted" "ERROR-ILLIQUID-CIRCULATION-SUPPLY-04" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -370,18 +370,18 @@ icsWithdrawalToken = V2.singleton icsWithdrawalTokenCurrSym icsWithdrawalTokenNa
 
 -- test runner
 
-runValidator :: VersionOracleConfig -> BuiltinData -> IlliquidCirculationSupplyRedeemer -> V2.ScriptContext -> BuiltinUnit
-runValidator versionOracleConfig datum redeemer ctx =
-  mkIlliquidCirculationSupplyValidatorUntyped
-    (toBuiltinData versionOracleConfig)
-    (toBuiltinData datum)
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
+runMintingPolicy :: VersionOracleConfig -> V2.ScriptContext -> CompiledCode BuiltinUnit
+runMintingPolicy versionOracleConfig ctx =
+  compiledAuthorityTokenPolicy
+    `appArg` Test.dummyBuiltinData
+    `appArg` versionOracleConfig
+    `appArg` Test.dummyBuiltinData
+    `appArg` ctx
 
-runPolicy :: VersionOracleConfig -> V2.ScriptContext -> BuiltinUnit
-runPolicy versionOracleConfig ctx =
-  mkIlliquidCirculationSupplyAuthorityTokenPolicyUntyped
-    Test.dummyBuiltinData
-    (toBuiltinData versionOracleConfig)
-    Test.dummyBuiltinData
-    (toBuiltinData ctx)
+runValidator :: VersionOracleConfig -> BuiltinData -> IlliquidCirculationSupplyRedeemer -> V2.ScriptContext -> CompiledCode BuiltinUnit
+runValidator versionOracleConfig datum redeemer ctx =
+  compiledValidator
+    `appArg` versionOracleConfig
+    `appArg` datum
+    `appArg` redeemer
+    `appArg` ctx

--- a/onchain/test/script-spec/PermissionedCandidates.hs
+++ b/onchain/test/script-spec/PermissionedCandidates.hs
@@ -53,7 +53,7 @@ permissionedCandidatesPolicyMintPassing =
 
 permissionedCandidatesPolicyMintFailing01 :: TestTree
 permissionedCandidatesPolicyMintFailing01 =
-  expectFail "should fail if not signed by the governance authority (ERROR-PERMISSIONED-CANDIDATES-POLICY-01)" $
+  expectFail "should fail if not signed by the governance authority" "ERROR-PERMISSIONED-CANDIDATES-POLICY-01" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -71,7 +71,7 @@ permissionedCandidatesPolicyMintFailing01 =
 
 permissionedCandidatesPolicyMintFailing02 :: TestTree
 permissionedCandidatesPolicyMintFailing02 =
-  expectFail "should fail if some tokens are not sent to permissionedCandidatesValidatorAddress (ERROR-PERMISSIONED-CANDIDATES-POLICY-02)" $
+  expectFail "should fail if some tokens are not sent to permissionedCandidatesValidatorAddress" "ERROR-PERMISSIONED-CANDIDATES-POLICY-02" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -134,7 +134,7 @@ permissionedCandidatesPolicyBurnPassingWithBurn =
 
 permissionedCandidatesPolicyBurnFailing03 :: TestTree
 permissionedCandidatesPolicyBurnFailing03 =
-  expectFail "should fail if not signed by the governance authority (ERROR-PERMISSIONED-CANDIDATES-POLICY-03)" $
+  expectFail "should fail if not signed by the governance authority" "ERROR-PERMISSIONED-CANDIDATES-POLICY-03" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -148,7 +148,7 @@ permissionedCandidatesPolicyBurnFailing03 =
 
 permissionedCandidatesPolicyBurnFailing04 :: TestTree
 permissionedCandidatesPolicyBurnFailing04 =
-  expectFail "should fail if outputs PermissionedCandidatesTokens (ERROR-PERMISSIONED-CANDIDATES-POLICY-04)" $
+  expectFail "should fail if outputs PermissionedCandidatesTokens" "ERROR-PERMISSIONED-CANDIDATES-POLICY-04" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -166,7 +166,7 @@ permissionedCandidatesPolicyBurnFailing04 =
 
 permissionedCandidatesPolicyBurnFailing05 :: TestTree
 permissionedCandidatesPolicyBurnFailing05 =
-  expectFail "should fail if script purpose is not minting (ERROR-PERMISSIONED-CANDIDATES-POLICY-05)" $
+  expectFail "should fail if script purpose is not minting" "ERROR-PERMISSIONED-CANDIDATES-POLICY-05" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -238,7 +238,7 @@ permissionedCandidatesValidatorUpdatePassingWithMintingPurpose =
 
 permissionedCandidatesValidatorUpdateFailing01 :: TestTree
 permissionedCandidatesValidatorUpdateFailing01 =
-  expectFail "should fail if not signed by the governance authority (ERROR-PERMISSIONED-CANDIDATES-VALIDATOR-01)" $
+  expectFail "should fail if not signed by the governance authority" "ERROR-PERMISSIONED-CANDIDATES-VALIDATOR-01" $
     runValidator
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -267,7 +267,7 @@ permissionedCandidatesValidatorRemovePassing =
 
 permissionedCandidatesValidatorRemoveFailing02 :: TestTree
 permissionedCandidatesValidatorRemoveFailing02 =
-  expectFail "should fail if not signed by the governance authority (ERROR-PERMISSIONED-CANDIDATES-VALIDATOR-02)" $
+  expectFail "should fail if not signed by the governance authority" "ERROR-PERMISSIONED-CANDIDATES-VALIDATOR-02" $
     runValidator
       Test.genesisUtxo
       Test.versionOracleConfig
@@ -301,20 +301,20 @@ permissionedCandidatesOracleToken = V2.singleton permissionedCandidatesCurrSym p
 
 -- test runner
 
-runMintingPolicy :: V2.TxOutRef -> VersionOracleConfig -> V2.Address -> PermissionedCandidatesPolicyRedeemer -> V2.ScriptContext -> BuiltinUnit
+runMintingPolicy :: V2.TxOutRef -> VersionOracleConfig -> V2.Address -> PermissionedCandidatesPolicyRedeemer -> V2.ScriptContext -> CompiledCode BuiltinUnit
 runMintingPolicy genesisUtxo vc permissionedCandidatesValidatorAddress' redeemer ctx =
-  mkMintingPolicyUntyped
-    (toBuiltinData genesisUtxo)
-    (toBuiltinData vc)
-    (toBuiltinData permissionedCandidatesValidatorAddress')
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
+  compiledMintingPolicy
+    `appArg` genesisUtxo
+    `appArg` vc
+    `appArg` permissionedCandidatesValidatorAddress'
+    `appArg` redeemer
+    `appArg` ctx
 
-runValidator :: V2.TxOutRef -> VersionOracleConfig -> BuiltinData -> PermissionedCandidatesValidatorRedeemer -> V2.ScriptContext -> BuiltinUnit
+runValidator :: V2.TxOutRef -> VersionOracleConfig -> BuiltinData -> PermissionedCandidatesValidatorRedeemer -> V2.ScriptContext -> CompiledCode BuiltinUnit
 runValidator genesisUtxo vc datum redeemer ctx =
-  mkValidatorUntyped
-    (toBuiltinData genesisUtxo)
-    (toBuiltinData vc)
-    (toBuiltinData datum)
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
+  compiledValidator
+    `appArg` genesisUtxo
+    `appArg` vc
+    `appArg` datum
+    `appArg` redeemer
+    `appArg` ctx

--- a/onchain/test/script-spec/Reserve.hs
+++ b/onchain/test/script-spec/Reserve.hs
@@ -9,7 +9,7 @@ import PlutusTx.Builtins.Internal (BuiltinUnit (..))
 import ScriptSpecUtils
 import Test.Tasty
 import TestValues qualified as Test
-import TrustlessSidechain.Reserve qualified as Reserve
+import TrustlessSidechain.Reserve
 import TrustlessSidechain.ScriptId qualified as ScriptId
 import TrustlessSidechain.Types qualified as Types
 
@@ -72,12 +72,14 @@ reserveAuthPolicyPassing =
 
 reserveAuthPolicyFailing01 :: TestTree
 reserveAuthPolicyFailing01 =
-  expectFail "should fail if not approved by governance (ERROR-RESERVE-AUTH-01)" $
+  expectFail "should fail if not approved by governance" "ERROR-RESERVE-AUTH-01" $
     runMintingPolicy
       Test.versionOracleConfig
       Test.dummyBuiltinData
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting reserveAuthPolicyCurrencySymbol
+          -- governance version oracle:
+          & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
           -- [ERROR] Governance token missing
           -- ReserveAuthPolicy VersionOracle
           & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ reserveValidatorVersionOracleUtxo]
@@ -99,7 +101,7 @@ reserveAuthPolicyFailing01 =
 
 reserveAuthPolicyFailing02 :: TestTree
 reserveAuthPolicyFailing02 =
-  expectFail "should fail if single reserve authentication token is not minted (ERROR-RESERVE-AUTH-02)" $
+  expectFail "should fail if single reserve authentication token is not minted" "ERROR-RESERVE-AUTH-02" $
     runMintingPolicy
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -127,7 +129,7 @@ reserveAuthPolicyFailing02 =
 
 reserveAuthPolicyFailing03 :: TestTree
 reserveAuthPolicyFailing03 =
-  expectFail "should fail if output reserve UTxO doesn't carry auth token (ERROR-RESERVE-AUTH-03)" $
+  expectFail "should fail if output reserve UTxO doesn't carry auth token" "ERROR-RESERVE-AUTH-03" $
     runMintingPolicy
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -155,7 +157,7 @@ reserveAuthPolicyFailing03 =
 
 reserveAuthPolicyFailing04 :: TestTree
 reserveAuthPolicyFailing04 =
-  expectFail "should fail if output reserve UTxO doesn't carry correct initial datum (ERROR-RESERVE-AUTH-04)" $
+  expectFail "should fail if output reserve UTxO doesn't carry correct initial datum" "ERROR-RESERVE-AUTH-04" $
     runMintingPolicy
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -192,7 +194,7 @@ reserveAuthPolicyFailing04 =
 
 reserveAuthPolicyFailing05 :: TestTree
 reserveAuthPolicyFailing05 =
-  expectFail "should fail if no unique output UTxO at the reserve address (ERROR-RESERVE-AUTH-05)" $
+  expectFail "should fail if no unique output UTxO at the reserve address" "ERROR-RESERVE-AUTH-05" $
     runMintingPolicy
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -233,7 +235,7 @@ reserveAuthPolicyFailing05 =
 
 reserveAuthPolicyFailing06 :: TestTree
 reserveAuthPolicyFailing06 =
-  expectFail "should fail if output reserve UTxO carries no inline datum or malformed datum (ERROR-RESERVE-AUTH-06)" $
+  expectFail "should fail if output reserve UTxO carries no inline datum or malformed datum" "ERROR-RESERVE-AUTH-06" $
     runMintingPolicy
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -362,13 +364,15 @@ reserveValidatorDepositPassing =
 
 reserveValidatorDepositFailing01 :: TestTree
 reserveValidatorDepositFailing01 =
-  expectFail "should fail if governance approval is not present (ERROR-RESERVE-01)" $
+  expectFail "should fail if governance approval is not present" "ERROR-RESERVE-01" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
       Types.DepositToReserve
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Spending reserveUtxo
+          -- governance version oracle:
+          & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
           -- [ERROR] NOT signed by governance
           -- ReserveAuthPolicy VersionOracle
           & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ reserveAuthPolicyVersionOracleUtxo]
@@ -411,7 +415,7 @@ reserveValidatorDepositFailing01 =
 
 reserveValidatorDepositFailing02 :: TestTree
 reserveValidatorDepositFailing02 =
-  expectFail "should fail if datum of the propagated reserve utxo changes (ERROR-RESERVE-02)" $
+  expectFail "should fail if datum of the propagated reserve utxo changes" "ERROR-RESERVE-02" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -468,7 +472,7 @@ reserveValidatorDepositFailing02 =
 
 reserveValidatorDepositFailing03 :: TestTree
 reserveValidatorDepositFailing03 =
-  expectFail "should fail if assets of the propagated reserve utxo don't increase by reserve tokens (ERROR-RESERVE-03)" $
+  expectFail "should fail if assets of the propagated reserve utxo don't increase by reserve tokens" "ERROR-RESERVE-03" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -574,7 +578,7 @@ reserveValidatorUpdatePassing =
 
 reserveValidatorUpdateFailing04 :: TestTree
 reserveValidatorUpdateFailing04 =
-  expectFail "should fail if no unique input utxo carrying authentication token (ERROR-RESERVE-04)" $
+  expectFail "should fail if no unique input utxo carrying authentication token" "ERROR-RESERVE-04" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -638,7 +642,7 @@ reserveValidatorUpdateFailing04 =
 
 reserveValidatorUpdateFailing05 :: TestTree
 reserveValidatorUpdateFailing05 =
-  expectFail "should fail if no unique output utxo at the reserve address and carrying authentication token (ERROR-RESERVE-05)" $
+  expectFail "should fail if no unique output utxo at the reserve address and carrying authentication token" "ERROR-RESERVE-05" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -698,7 +702,7 @@ reserveValidatorUpdateFailing05 =
 
 reserveValidatorUpdateFailing06 :: TestTree
 reserveValidatorUpdateFailing06 =
-  expectFail "should fail if datum of input reserve utxo malformed (ERROR-RESERVE-06)" $
+  expectFail "should fail if datum of input reserve utxo malformed" "ERROR-RESERVE-06" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -748,7 +752,7 @@ reserveValidatorUpdateFailing06 =
 
 reserveValidatorUpdateFailing07 :: TestTree
 reserveValidatorUpdateFailing07 =
-  expectFail "should fail if datum of output reserve utxo malformed (ERROR-RESERVE-07)" $
+  expectFail "should fail if datum of output reserve utxo malformed" "ERROR-RESERVE-07" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -789,13 +793,15 @@ reserveValidatorUpdateFailing07 =
 
 reserveValidatorUpdateFailing08 :: TestTree
 reserveValidatorUpdateFailing08 =
-  expectFail "should fail if governance approval is not present (ERROR-RESERVE-08)" $
+  expectFail "should fail if governance approval is not present" "ERROR-RESERVE-08" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
       Types.UpdateReserve
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Spending reserveUtxo
+          -- governance version oracle:
+          & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
           -- [ERROR] not signed by governance
           -- ReserveAuthPolicy VersionOracle
           & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ reserveAuthPolicyVersionOracleUtxo]
@@ -836,7 +842,7 @@ reserveValidatorUpdateFailing08 =
 
 reserveValidatorUpdateFailing09 :: TestTree
 reserveValidatorUpdateFailing09 =
-  expectFail "should fail if datum of the propagated reserve utxo changes not only by immutable settings (ERROR-RESERVE-09)" $
+  expectFail "should fail if datum of the propagated reserve utxo changes not only by immutable settings" "ERROR-RESERVE-09" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -885,7 +891,7 @@ reserveValidatorUpdateFailing09 =
 
 reserveValidatorUpdateFailing10 :: TestTree
 reserveValidatorUpdateFailing10 =
-  expectFail "should fail if assets of the propagated reserve utxo change (ERROR-RESERVE-10)" $
+  expectFail "should fail if assets of the propagated reserve utxo change" "ERROR-RESERVE-10" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -934,7 +940,7 @@ reserveValidatorUpdateFailing10 =
 
 reserveValidatorUpdateFailing18 :: TestTree
 reserveValidatorUpdateFailing18 =
-  expectFail "should fail if continuing output exists without an authentication token (ERROR-RESERVE-18)" $
+  expectFail "should fail if continuing output exists without an authentication token" "ERROR-RESERVE-18" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -1059,7 +1065,7 @@ reserveValidatorTransferToICSPassing =
 
 reserveValidatorTransferToICSFailing11 :: TestTree
 reserveValidatorTransferToICSFailing11 =
-  expectFail "should fail if assets of the propagated reserve utxo don't decrease by reserve tokens in desired way (ERROR-RESERVE-11)" $
+  expectFail "should fail if assets of the propagated reserve utxo don't decrease by reserve tokens in desired way" "ERROR-RESERVE-11" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -1134,7 +1140,7 @@ reserveValidatorTransferToICSFailing11 =
 
 reserveValidatorTransferToICSFailing12 :: TestTree
 reserveValidatorTransferToICSFailing12 =
-  expectFail "should fail if datum of the propagated reserve utxo changes not only by stats in desired way (ERROR-RESERVE-12)" $
+  expectFail "should fail if datum of the propagated reserve utxo changes not only by stats in desired way" "ERROR-RESERVE-12" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -1215,7 +1221,7 @@ reserveValidatorTransferToICSFailing12 =
 
 reserveValidatorTransferToICSFailing13 :: TestTree
 reserveValidatorTransferToICSFailing13 =
-  expectFail "should fail if incorrect amount of reserve tokens goes into an illiquid circulation supply (ERROR-RESERVE-13)" $
+  expectFail "should fail if incorrect amount of reserve tokens goes into an illiquid circulation supply" "ERROR-RESERVE-13" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -1290,7 +1296,7 @@ reserveValidatorTransferToICSFailing13 =
 
 reserveValidatorTransferToICSFailing14 :: TestTree
 reserveValidatorTransferToICSFailing14 =
-  expectFail "should fail if no unique output utxo at the illiquid circulation supply address (ERROR-RESERVE-14)" $
+  expectFail "should fail if no unique output utxo at the illiquid circulation supply address" "ERROR-RESERVE-14" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -1426,13 +1432,15 @@ reserveValidatorHandoverPassing =
 
 reserveValidatorHandoverFailing15 :: TestTree
 reserveValidatorHandoverFailing15 =
-  expectFail "should fail if governance approval is not present (ERROR-RESERVE-15)" $
+  expectFail "should fail if governance approval is not present" "ERROR-RESERVE-15" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
       Types.Handover
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Spending reserveUtxo
+          -- governance version oracle:
+          & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
           -- [ERROR] not signed by governance
           -- ReserveAuthPolicy VersionOracle
           & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ reserveAuthPolicyVersionOracleUtxo]
@@ -1475,7 +1483,7 @@ reserveValidatorHandoverFailing15 =
 
 reserveValidatorHandoverFailing16 :: TestTree
 reserveValidatorHandoverFailing16 =
-  expectFail "should fail if an authentication token is not burnt (ERROR-RESERVE-16)" $
+  expectFail "should fail if an authentication token is not burnt" "ERROR-RESERVE-16" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -1525,7 +1533,7 @@ reserveValidatorHandoverFailing16 =
 
 reserveValidatorHandoverFailing17 :: TestTree
 reserveValidatorHandoverFailing17 =
-  expectFail "should fail if not all reserve tokens are transferred to illiquid circulation supply (ERROR-RESERVE-17)" $
+  expectFail "should fail if not all reserve tokens are transferred to illiquid circulation supply" "ERROR-RESERVE-17" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -1583,7 +1591,7 @@ reserveValidatorHandoverFailing17 =
 
 reserveValidatorHandoverFailing18 :: TestTree
 reserveValidatorHandoverFailing18 =
-  expectFail "should fail if governance approval is not present (ERROR-RESERVE-18)" $
+  expectFail "should fail if governance approval is not present" "ERROR-RESERVE-18" $
     runValidator
       Test.versionOracleConfig
       Test.dummyBuiltinData
@@ -1748,17 +1756,17 @@ vFunctionCurrSym = V2.CurrencySymbol "vFunctionScriptHash"
 
 -- test runner
 
-runMintingPolicy :: Types.VersionOracleConfig -> BuiltinData -> V2.ScriptContext -> BuiltinUnit
+runMintingPolicy :: Types.VersionOracleConfig -> BuiltinData -> V2.ScriptContext -> CompiledCode BuiltinUnit
 runMintingPolicy vc redeemer ctx =
-  Reserve.mkReserveAuthPolicyUntyped
-    (toBuiltinData vc)
-    redeemer
-    (toBuiltinData ctx)
+  compiledReserveAuthPolicy
+    `appArg` vc
+    `appArg` redeemer
+    `appArg` ctx
 
-runValidator :: Types.VersionOracleConfig -> BuiltinData -> Types.ReserveRedeemer -> V2.ScriptContext -> BuiltinUnit
+runValidator :: Types.VersionOracleConfig -> BuiltinData -> Types.ReserveRedeemer -> V2.ScriptContext -> CompiledCode BuiltinUnit
 runValidator vc datum redeemer ctx =
-  Reserve.mkReserveValidatorUntyped
-    (toBuiltinData vc)
-    datum
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
+  compiledValidator
+    `appArg` vc
+    `appArg` datum
+    `appArg` redeemer
+    `appArg` ctx

--- a/onchain/test/script-spec/ScriptSpecUtils.hs
+++ b/onchain/test/script-spec/ScriptSpecUtils.hs
@@ -104,7 +104,7 @@ expectFail testName expectedTrace code = testCase testName do
       assertBool
         ("Didn't fail with expected trace. expected: " <> Text.unpack expectedTrace <> " actual: " <> show logs)
         $ expectedTrace `elem` logs
-    (Right _actual, _counting, _logs) -> assertFailure "Expected failure but script passed!"
+    (Right _actual, _counting, _logs) -> assertFailure $ "Expected failure but script passed! expected: " <> Text.unpack expectedTrace
 
 -- lens
 

--- a/onchain/test/script-spec/ScriptSpecUtils.hs
+++ b/onchain/test/script-spec/ScriptSpecUtils.hs
@@ -1,7 +1,8 @@
 module ScriptSpecUtils where
 
-import Control.Exception
 import Control.Lens
+import Data.Text (Text)
+import Data.Text qualified as Text
 import PlutusLedgerApi.V1.Interval (interval)
 import PlutusLedgerApi.V2 qualified as V2
 import PlutusTx
@@ -9,6 +10,13 @@ import PlutusTx.AssocMap qualified as Map
 import PlutusTx.Prelude (BuiltinUnit)
 import Test.Tasty
 import Test.Tasty.HUnit
+
+import PlutusCore.Default (DefaultUni (DefaultUniUnit), Some (..), ValueOf (..))
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCekParametersForTesting)
+import PlutusCore.Version (plcVersion100)
+import UntypedPlutusCore.Core.Type (Term (Constant), progTerm)
+import UntypedPlutusCore.Evaluation.Machine.Cek (counting, logEmitter)
+import UntypedPlutusCore.Evaluation.Machine.Cek.Internal (runCekDeBruijn)
 
 emptyScriptContext :: V2.ScriptContext
 emptyScriptContext =
@@ -76,19 +84,27 @@ mkTxOutNoScriptHash txOutAddress txOutValue datum =
 
 -- test functions
 
-expectFail :: TestName -> BuiltinUnit -> TestTree
-expectFail str a = testCase str do
-  res <- catch (Right <$> evaluate a) \(SomeException _) -> return $ Left ()
-  case res of
-    Right _ -> assertFailure ("expected fail")
-    _ -> return ()
+appArg :: (ToData b) => CompiledCode (BuiltinData -> a) -> b -> CompiledCode a
+appArg a b = a `unsafeApplyCode` liftCode plcVersion100 (toBuiltinData b)
 
-expectSuccess :: TestName -> BuiltinUnit -> TestTree
-expectSuccess str a = testCase str do
-  res <- catch (Right <$> evaluate a) \(SomeException e) -> return $ Left $ show e
-  case res of
-    Left e -> assertFailure ("expected pass, received:\n" <> e)
-    _ -> return ()
+expectSuccess :: TestName -> CompiledCode BuiltinUnit -> TestTree
+expectSuccess testName code = testCase testName do
+  let plc = getPlc code ^. progTerm
+  case runCekDeBruijn defaultCekParametersForTesting counting logEmitter plc of
+    (Left ex, _counting, _logs) -> assertFailure $ show ex
+    (Right actual, _counting, _logs) -> assertEqual "Evaluation has succeeded" constUnit actual
+  where
+    constUnit = Constant () (Some (ValueOf DefaultUniUnit ()))
+
+expectFail :: TestName -> Text -> CompiledCode BuiltinUnit -> TestTree
+expectFail testName expectedTrace code = testCase testName do
+  let plc = getPlc code ^. progTerm
+  case runCekDeBruijn defaultCekParametersForTesting counting logEmitter plc of
+    (Left _ex, _counting, logs) ->
+      assertBool
+        ("Didn't fail with expected trace. expected: " <> Text.unpack expectedTrace <> " actual: " <> show logs)
+        $ expectedTrace `elem` logs
+    (Right _actual, _counting, _logs) -> assertFailure "Expected failure but script passed!"
 
 -- lens
 

--- a/onchain/test/script-spec/Versioning.hs
+++ b/onchain/test/script-spec/Versioning.hs
@@ -65,7 +65,7 @@ versioningPolicyInitializePassing =
 
 versioningPolicyInitializeFailing01 :: TestTree
 versioningPolicyInitializeFailing01 =
-  expectFail "should fail on no genesis utxo (ERROR-VERSION-POLICY-01)" $
+  expectFail "should fail on no genesis utxo" "ERROR-VERSION-POLICY-01" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
@@ -79,7 +79,7 @@ versioningPolicyInitializeFailing01 =
 
 versioningPolicyInitializeFailing02NoOutput :: TestTree
 versioningPolicyInitializeFailing02NoOutput =
-  expectFail "should fail on empty outputs (ERROR-VERSION-POLICY-02)" $
+  expectFail "should fail on empty outputs" "ERROR-VERSION-POLICY-02" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
@@ -93,7 +93,7 @@ versioningPolicyInitializeFailing02NoOutput =
 
 versioningPolicyInitializeFailing02NoDatum :: TestTree
 versioningPolicyInitializeFailing02NoDatum =
-  expectFail "should fail on no datum in output (ERROR-VERSION-POLICY-02)" $
+  expectFail "should fail on no datum in output" "ERROR-VERSION-POLICY-02" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
@@ -108,7 +108,7 @@ versioningPolicyInitializeFailing02NoDatum =
 
 versioningPolicyInitializeFailing02InvalidDatum :: TestTree
 versioningPolicyInitializeFailing02InvalidDatum =
-  expectFail "should fail on invalid datum in output (ERROR-VERSION-POLICY-02)" $
+  expectFail "should fail on invalid datum in output" "ERROR-VERSION-POLICY-02" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
@@ -125,7 +125,7 @@ versioningPolicyInitializeFailing02InvalidDatum =
 
 versioningPolicyInitializeFailing03 :: TestTree
 versioningPolicyInitializeFailing03 =
-  expectFail "should fail on invalid token being minted (ERROR-VERSION-POLICY-03)" $
+  expectFail "should fail on invalid token being minted" "ERROR-VERSION-POLICY-03" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
@@ -133,6 +133,7 @@ versioningPolicyInitializeFailing03 =
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoOutRef .~ Test.genesisUtxo]
+          & _scriptContextTxInfo . _txInfoOutputs <>~ [Test.versioningTokenUtxo]
           & _scriptContextTxInfo . _txInfoMint .~ Test.wrongToken
       )
 
@@ -147,86 +148,93 @@ versioningPolicyMintPassing =
       (MintVersionOracle Test.versionOracle Test.versioningValidatorScriptHash)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
+          -- governance version oracle:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
+          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
           & _scriptContextTxInfo . _txInfoOutputs <>~ [Test.versioningTokenUtxo]
           & _scriptContextTxInfo . _txInfoMint <>~ Test.versionOracleToken 1
-          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
       )
 
 versioningPolicyMintFailing04NoOutput :: TestTree
 versioningPolicyMintFailing04NoOutput =
-  expectFail "should fail on empty outputs (ERROR-VERSION-POLICY-04)" $
+  expectFail "should fail on empty outputs" "ERROR-VERSION-POLICY-04" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
       (MintVersionOracle Test.versionOracle Test.versioningValidatorScriptHash)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
+          -- governance version oracle:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
+          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
           -- no outputs provided
           & _scriptContextTxInfo . _txInfoMint <>~ Test.versionOracleToken 1
-          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
       )
 
 versioningPolicyMintFailing04NoDatum :: TestTree
 versioningPolicyMintFailing04NoDatum =
-  expectFail "should fail on no datum in output (ERROR-VERSION-POLICY-04)" $
+  expectFail "should fail on no datum in output" "ERROR-VERSION-POLICY-04" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
       (MintVersionOracle Test.versionOracle Test.versioningValidatorScriptHash)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
+          -- governance version oracle:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
+          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
           -- output has missing datum:
           & _scriptContextTxInfo . _txInfoOutputs <>~ [Test.versioningTokenUtxo & _txOutDatum .~ V2.NoOutputDatum]
           & _scriptContextTxInfo . _txInfoMint <>~ Test.versionOracleToken 1
-          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
       )
 
 versioningPolicyMintFailing04InvalidDatum :: TestTree
 versioningPolicyMintFailing04InvalidDatum =
-  expectFail "should fail on invalid datum in output (ERROR-VERSION-POLICY-04)" $
+  expectFail "should fail on invalid datum in output" "ERROR-VERSION-POLICY-04" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
       (MintVersionOracle Test.versionOracle Test.versioningValidatorScriptHash)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
+          -- governance version oracle:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
+          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
           -- output has invalid datum:
           & _scriptContextTxInfo . _txInfoOutputs <>~ [Test.versioningTokenUtxo & _txOutDatum .~ V2.OutputDatum invalidDatum]
           & _scriptContextTxInfo . _txInfoMint <>~ Test.versionOracleToken 1
-          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
       )
   where
     invalidDatum = V2.Datum $ toBuiltinData (0 :: Integer)
 
 versioningPolicyMintFailing05 :: TestTree
 versioningPolicyMintFailing05 =
-  expectFail "should fail if not signed by gov auth (ERROR-VERSION-POLICY-05)" $
+  expectFail "should fail if governance approval is not present" "ERROR-VERSION-POLICY-05" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
       (MintVersionOracle Test.versionOracle Test.versioningValidatorScriptHash)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
-          -- gov token not in inputs
+          -- governance version oracle:
+          & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
+          -- [ERROR] not signed by governance
           & _scriptContextTxInfo . _txInfoOutputs <>~ [Test.versioningTokenUtxo]
           & _scriptContextTxInfo . _txInfoMint <>~ Test.versionOracleToken 1
-          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
       )
 
 versioningPolicyMintFailing06 :: TestTree
 versioningPolicyMintFailing06 =
-  expectFail "should fail on invalid token being minted (ERROR-VERSION-POLICY-06)" $
+  expectFail "should fail on invalid token being minted" "ERROR-VERSION-POLICY-06" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
       (MintVersionOracle Test.versionOracle Test.versioningValidatorScriptHash)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
+          -- governance version oracle:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
+          & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
           & _scriptContextTxInfo . _txInfoOutputs <>~ [Test.versioningTokenUtxo]
           & _scriptContextTxInfo . _txInfoMint <>~ Test.wrongToken
       )
@@ -249,13 +257,14 @@ versioningPolicyBurnPassing =
 
 versioningPolicyBurnFailing07NoVersioningInput :: TestTree
 versioningPolicyBurnFailing07NoVersioningInput =
-  expectFail "should fail on missing versioning utxo in inputs (ERROR-VERSION-POLICY-07)" $
+  expectFail "should fail on missing versioning utxo in inputs" "ERROR-VERSION-POLICY-07" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
       (BurnVersionOracle Test.versionOracle)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
+          -- governance version oracle:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
           -- no versioning utxo in inputs
           & _scriptContextTxInfo . _txInfoMint <>~ Test.governanceToken
@@ -263,13 +272,14 @@ versioningPolicyBurnFailing07NoVersioningInput =
 
 versioningPolicyBurnFailing07VersioningInputHasNoDatum :: TestTree
 versioningPolicyBurnFailing07VersioningInputHasNoDatum =
-  expectFail "should fail on versioning utxo with no datum in inputs (ERROR-VERSION-POLICY-07)" $
+  expectFail "should fail on versioning utxo with no datum in inputs" "ERROR-VERSION-POLICY-07" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
       (BurnVersionOracle Test.versionOracle)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
+          -- governance version oracle:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
           -- versioning utxo has missing datum:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ (Test.versioningTokenUtxo & _txOutDatum .~ V2.NoOutputDatum)]
@@ -278,13 +288,14 @@ versioningPolicyBurnFailing07VersioningInputHasNoDatum =
 
 versioningPolicyBurnFailing07VersioningInputHasInvalidDatum :: TestTree
 versioningPolicyBurnFailing07VersioningInputHasInvalidDatum =
-  expectFail "should fail on versioning utxo with invalid datum in inputs (ERROR-VERSION-POLICY-07)" $
+  expectFail "should fail on versioning utxo with invalid datum in inputs" "ERROR-VERSION-POLICY-07" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
       (BurnVersionOracle Test.versionOracle)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
+          -- governance version oracle:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
           -- versioning utxo has invalid datum:
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ (Test.versioningTokenUtxo & _txOutDatum .~ V2.OutputDatum invalidDatum)]
@@ -295,7 +306,7 @@ versioningPolicyBurnFailing07VersioningInputHasInvalidDatum =
 
 versioningPolicyBurnFailing08 :: TestTree
 versioningPolicyBurnFailing08 =
-  expectFail "should fail if versioning utxo is in output (ERROR-VERSION-POLICY-08)" $
+  expectFail "should fail if versioning utxo is in output" "ERROR-VERSION-POLICY-08" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
@@ -310,19 +321,22 @@ versioningPolicyBurnFailing08 =
 
 versioningPolicyBurnFailing09 :: TestTree
 versioningPolicyBurnFailing09 =
-  expectFail "should fail if not signed by gov authority (ERROR-VERSION-POLICY-09)" $
+  expectFail "should fail if governance approval is not present" "ERROR-VERSION-POLICY-09" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
       (BurnVersionOracle Test.versionOracle)
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Minting Test.versioningCurrSym
+          -- governance version oracle:
+          & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
+          -- [ERROR] not signed by governance
           & _scriptContextTxInfo . _txInfoInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.versioningTokenUtxo]
       )
 
 versioningPolicyNotMintFailing :: TestTree
 versioningPolicyNotMintFailing =
-  expectFail "should fail if script purpose is not minting (ERROR-VERSION-POLICY-10)" $
+  expectFail "should fail if script purpose is not minting" "ERROR-VERSION-POLICY-10" $
     runMintingPolicy
       Test.genesisUtxo
       Test.versionValidatorAddress
@@ -385,13 +399,15 @@ versioningValidatorPassing =
 
 versioningValidatorFailing01 :: TestTree
 versioningValidatorFailing01 =
-  expectFail "should fail if governance approval is not present (ERROR-VERSION-VALIDATOR-01)" $
+  expectFail "should fail if governance approval is not present" "ERROR-VERSION-VALIDATOR-01" $
     runValidator
       Test.genesisUtxo
       versionOracleDatum
       Test.versionOracle
       ( emptyScriptContext
           & _scriptContextPurpose .~ V2.Spending versioningUtxo
+          -- governance version oracle:
+          & _scriptContextTxInfo . _txInfoReferenceInputs <>~ [emptyTxInInfo & _txInInfoResolved .~ Test.governanceTokenUtxo]
           -- [ERROR] not signed by governance
           -- [INPUT] Versioning UTXO:
           & _scriptContextTxInfo . _txInfoInputs
@@ -418,7 +434,7 @@ versioningValidatorFailing01 =
 
 versioningValidatorFailing02 :: TestTree
 versioningValidatorFailing02 =
-  expectFail "should fail if version oracle in the datum does not match the redeemer (ERROR-VERSION-VALIDATOR-02)" $
+  expectFail "should fail if version oracle in the datum does not match the redeemer" "ERROR-VERSION-VALIDATOR-02" $
     runValidator
       Test.genesisUtxo
       -- [ERROR] version oracle does not match one in datum:
@@ -463,7 +479,7 @@ versioningValidatorFailing02 =
 
 versioningValidatorFailing03 :: TestTree
 versioningValidatorFailing03 =
-  expectFail "should fail if transaction outputs version tokens to non-versioning address (ERROR-VERSION-VALIDATOR-03)" $
+  expectFail "should fail if transaction outputs version tokens to non-versioning address" "ERROR-VERSION-VALIDATOR-03" $
     runValidator
       Test.genesisUtxo
       versionOracleDatum
@@ -499,7 +515,7 @@ versioningValidatorFailing03 =
 
 versioningValidatorFailing04 :: TestTree
 versioningValidatorFailing04 =
-  expectFail "should fail if invalid script purpose is provided (ERROR-VERSION-VALIDATOR-04)" $
+  expectFail "should fail if invalid script purpose is provided" "ERROR-VERSION-VALIDATOR-04" $
     runValidator
       Test.genesisUtxo
       versionOracleDatum
@@ -535,7 +551,7 @@ versioningValidatorFailing04 =
 
 versioningValidatorFailing05 :: TestTree
 versioningValidatorFailing05 =
-  expectFail "should fail if transaction does not have own input (ERROR-VERSION-VALIDATOR-05)" $
+  expectFail "should fail if transaction does not have own input" "ERROR-VERSION-VALIDATOR-05" $
     runValidator
       Test.genesisUtxo
       versionOracleDatum
@@ -579,18 +595,18 @@ someAddress = V2.Address (V2.PubKeyCredential "098709870987098709870987098709870
 
 -- test runner
 
-runMintingPolicy :: V2.TxOutRef -> V2.Address -> VersionOraclePolicyRedeemer -> V2.ScriptContext -> BuiltinUnit
+runMintingPolicy :: V2.TxOutRef -> V2.Address -> VersionOraclePolicyRedeemer -> V2.ScriptContext -> CompiledCode BuiltinUnit
 runMintingPolicy genesisUtxo validatorAddress redeemer ctx =
-  mkVersionOraclePolicyUntyped
-    (toBuiltinData genesisUtxo)
-    (toBuiltinData validatorAddress)
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
+  compiledVersionOraclePolicy
+    `appArg` genesisUtxo
+    `appArg` validatorAddress
+    `appArg` redeemer
+    `appArg` ctx
 
-runValidator :: V2.TxOutRef -> VersionOracleDatum -> VersionOracle -> V2.ScriptContext -> BuiltinUnit
+runValidator :: V2.TxOutRef -> VersionOracleDatum -> VersionOracle -> V2.ScriptContext -> CompiledCode BuiltinUnit
 runValidator genesisUtxo datum redeemer ctx =
-  mkVersionOracleValidatorUntyped
-    (toBuiltinData genesisUtxo)
-    (toBuiltinData datum)
-    (toBuiltinData redeemer)
-    (toBuiltinData ctx)
+  compiledVersionOracleValidator
+    `appArg` genesisUtxo
+    `appArg` datum
+    `appArg` redeemer
+    `appArg` ctx

--- a/onchain/trustless-sidechain.cabal
+++ b/onchain/trustless-sidechain.cabal
@@ -237,7 +237,9 @@ test-suite roundtrip
   hs-source-dirs: test/roundtrip
 
 test-suite script-specs
-  import:         common-lang, common-optimized-parallel, common-script-lang
+  import:
+    common-lang, common-optimized-parallel, common-script-lang, common-lang-traced
+
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   other-modules:


### PR DESCRIPTION
This PR changes spec tests to use the actual compiled UPLC scripts instead of their original Haskell versions, as there are differences in strictness.

It is now also possible to check for the specific error codes. This led to fixing some tests where the test was not failing as expected.