### PR TITLE
Add licenses to Rust crates

### DIFF
--- a/.changes/unreleased/Fixed-20250917-112100.yaml
+++ b/.changes/unreleased/Fixed-20250917-112100.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Rust crates now include licenses in metadata
+time: 2025-09-17T11:21:00.531603296-04:00

--- a/raw-scripts-traced/Cargo.toml
+++ b/raw-scripts-traced/Cargo.toml
@@ -2,6 +2,7 @@
 name = "raw-scripts-traced"
 version = "8.1.0"
 edition = "2021"
+license-file = "../LICENSE"
 
 [dependencies]
 hex-literal = "0.4.1"

--- a/raw-scripts/Cargo.toml
+++ b/raw-scripts/Cargo.toml
@@ -2,6 +2,7 @@
 name = "raw-scripts"
 version = "8.1.0"
 edition = "2021"
+license-file = "../LICENSE"
 
 [dependencies]
 hex-literal = "0.4.1"


### PR DESCRIPTION
`cargo deny` complains about these crates missing licenses when used in other repos. This references the repo's license file to appease it.

### Prereview checklist

- [x] Changes have been documented by running `changie new`
- [x] `partner-chains` repo tests work against updated scripts if changes are intended as non-breaking
